### PR TITLE
Clean up VisualizationState and serialization

### DIFF
--- a/libraries/AppInsightsSupport/ApplicationInsightsLogLoader.cs
+++ b/libraries/AppInsightsSupport/ApplicationInsightsLogLoader.cs
@@ -93,7 +93,9 @@ public class ApplicationInsightsLogLoader
         using var vizDoc = JsonDocument.Parse(viz);
         var queryViz = vizDoc.RootElement.GetProperty("visualization");
         var visState = queryViz.GetString().NullToEmpty();
-        return new VisualizationState(visState, ImmutableDictionary<string, object>.Empty);
+
+        //TODO - accept other properties
+        return new VisualizationState(visState, ImmutableDictionary<string, string>.Empty);
     }
 
 }

--- a/libraries/FileFormats/KustoResultSerializer.cs
+++ b/libraries/FileFormats/KustoResultSerializer.cs
@@ -30,6 +30,7 @@ public class KustoResultSerializer(ITableSerializer serializer,string format)
             StreamFormat = format,
             ResultStream = str,
             VisualizationChartType = result.Visualization.ChartType,
+            VisualizationProperties = result.Visualization.Properties.ToDictionary(),
             Duration = result.QueryDuration.TotalMilliseconds,
             Error = result.Error
         };
@@ -43,7 +44,8 @@ public class KustoResultSerializer(ITableSerializer serializer,string format)
         var text = Convert.FromBase64String(dto.ResultStream);
         //TODO could keep this in a stream by using CryptoStream
         var table = await GetTable(text);
-        var vis = new VisualizationState(dto.VisualizationChartType, ImmutableDictionary<string, object>.Empty);
+        var visualizationProperties = dto.VisualizationProperties.ToImmutableDictionary();
+        var vis = new VisualizationState(dto.VisualizationChartType, visualizationProperties);
         var duration = TimeSpan.FromMilliseconds(dto.Duration);
         return new KustoQueryResult(dto.Query, table, vis, duration, dto.Error);
     }

--- a/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.Render.cs
+++ b/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.Render.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using KustoLoco.Core.InternalRepresentation;
 using KustoLoco.Core.InternalRepresentation.Nodes.Expressions.QueryOperators;
 
@@ -12,9 +14,9 @@ internal partial class TreeEvaluator
     public override EvaluationResult VisitRenderOperator(IRRenderOperatorNode node, EvaluationContext context)
     {
         Debug.Assert(context.Left != EvaluationResult.Null);
-
+       
         return TabularResult.CreateWithVisualisation(
             context.Left.Value,
-            new VisualizationState(ChartType: node.ChartType, node.Items));
+            new VisualizationState(ChartType: node.ChartType,node.Items));
     }
 }

--- a/libraries/KustoLoco.Core/Evaluation/VisualizationState.cs
+++ b/libraries/KustoLoco.Core/Evaluation/VisualizationState.cs
@@ -2,11 +2,11 @@
 
 namespace KustoLoco.Core.Evaluation;
 
-public record VisualizationState(string ChartType, ImmutableDictionary<string, object> Items)
+public record VisualizationState(string ChartType, ImmutableDictionary<string, string> Properties)
 {
     public static readonly VisualizationState Empty =
-        new(string.Empty, ImmutableDictionary<string, object>.Empty);
+        new(string.Empty, ImmutableDictionary<string, string>.Empty);
 
     public string PropertyOr(string propertyName, string fallback)
-        => Items.TryGetValue(propertyName, out var v) ? v.ToString() ?? fallback : fallback;
+        => Properties.TryGetValue(propertyName, out var v) ? v : fallback;
 }

--- a/libraries/KustoLoco.Core/InternalRepresentation/Nodes/Expressions/QueryOperators/IRRenderOperatorNode.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/Nodes/Expressions/QueryOperators/IRRenderOperatorNode.cs
@@ -9,7 +9,7 @@ namespace KustoLoco.Core.InternalRepresentation.Nodes.Expressions.QueryOperators
 
 internal class IRRenderOperatorNode : IRQueryOperatorNode
 {
-    public IRRenderOperatorNode(string chartType, ImmutableDictionary<string, object> items, TypeSymbol resultType)
+    public IRRenderOperatorNode(string chartType, ImmutableDictionary<string, string> items, TypeSymbol resultType)
         : base(resultType)
     {
         ChartType = chartType;
@@ -17,7 +17,7 @@ internal class IRRenderOperatorNode : IRQueryOperatorNode
     }
 
     public string ChartType { get; }
-    public ImmutableDictionary<string, object> Items { get; }
+    public ImmutableDictionary<string, string> Items { get; }
 
     public override int ChildCount => 0;
     public override IRNode GetChild(int index) => throw new ArgumentOutOfRangeException(nameof(index));

--- a/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.Render.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.Render.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using KustoLoco.Core.Util;
 using Kusto.Language.Syntax;
 using KustoLoco.Core.InternalRepresentation.Nodes.Expressions.QueryOperators;
+using NotNullStrings;
 
 
 namespace KustoLoco.Core.InternalRepresentation;
@@ -16,16 +17,15 @@ internal partial class IRTranslator
     public override IRNode VisitRenderOperator(RenderOperator node)
     {
         var chartType = node.ChartType.Text;
-        var items = new Dictionary<string, object>();
+        var items = new Dictionary<string, string>();
         if (node.WithClause == null)
             return new IRRenderOperatorNode(chartType: chartType,
-                items: items.ToImmutableDictionary(),
+                items: ImmutableDictionary<string, string>.Empty, 
                 node.ResultType);
 
         foreach (var prop in node.WithClause.Properties)
         {
             var element = prop.Element;
-
 
             if (element.Expression is not LiteralExpression literalExpression)
             {
@@ -34,7 +34,7 @@ internal partial class IRTranslator
             }
 
             var val = literalExpression.LiteralValue;
-            items.Add(element.Name.SimpleName, val);
+            items.Add(element.Name.SimpleName, val.ToString().NullToEmpty());
         }
 
         return new IRRenderOperatorNode(chartType: chartType,

--- a/libraries/KustoLoco.Core/KustoResultDto.cs
+++ b/libraries/KustoLoco.Core/KustoResultDto.cs
@@ -1,4 +1,6 @@
-﻿namespace KustoLoco.Core;
+﻿using System.Collections.Generic;
+
+namespace KustoLoco.Core;
 
 /// <summary>
 /// A Dto that represents a *serialized* QueryResult
@@ -19,5 +21,6 @@ public class KustoResultDto
     public string StreamFormat { get; set; } = string.Empty;
     public string ResultStream { get; set; } = string.Empty;
     public string VisualizationChartType { get; set; } = string.Empty;
+    public Dictionary<string, string> VisualizationProperties { get; set; } = new Dictionary<string, string>();
     public string Error { get; set; } = string.Empty;
 }

--- a/test/CoreTests/EndToEndTests.cs
+++ b/test/CoreTests/EndToEndTests.cs
@@ -4024,8 +4024,8 @@ aaathis is a test";
         var result = (TabularResult)engine.Evaluate(Array.Empty<ITableSource>(), query);
         var vis = result.VisualizationState;
         vis.ChartType.Should().Be("barchart");
-        vis.Items["legend"].Should().Be("visible");
-        vis.Items["ymax"].Should().Be(100);
+        vis.Properties["legend"].Should().Be("visible");
+        vis.Properties["ymax"].Should().Be("100");
     }
 
     [Fact]


### PR DESCRIPTION
Clean up VisualizationState and serialization to allow visualisation properties to be transferred more easily