### PR TITLE
Misc built-in function fixes

### DIFF
--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/Aggregates/MaxAggregate.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/Aggregates/MaxAggregate.cs
@@ -47,7 +47,7 @@ internal partial class MaxAggregate
     internal static TimeSpan? TsImplFinish(NumericAggregate context)
         => context.Count == 0 ? null : new TimeSpan((long)context.Total);
 
-    internal static DateTime DtImpl(NumericAggregate context, TimeSpan n)
+    internal static DateTime DtImpl(NumericAggregate context, DateTime n)
     {
         context.Total = context.Count == 0 ? n.Ticks : Math.Max(context.Total, n.Ticks);
         context.Count++;

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/Aggregates/MinAggregate.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/Aggregates/MinAggregate.cs
@@ -47,7 +47,7 @@ internal partial class MinAggregate
     internal static TimeSpan? TsImplFinish(NumericAggregate context)
         => context.Count == 0 ? null : new TimeSpan((long)context.Total);
 
-    internal static DateTime DtImpl(NumericAggregate context, TimeSpan n)
+    internal static DateTime DtImpl(NumericAggregate context, DateTime n)
     {
         context.Total = context.Count == 0 ? n.Ticks : Math.Min(context.Total, n.Ticks);
         context.Count++;

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/DatetimeDiffFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/DatetimeDiffFunction.cs
@@ -9,7 +9,7 @@ internal partial class DatetimeDiffFunction
     //It's unclear from the documentation whether things like "day" should be rounded or truncated
     private static long Impl(string period, DateTime a, DateTime b)
     {
-        return period switch
+        return period.ToLowerInvariant() switch
         {
             "year" => a.Year - b.Year,
             "month" => (a.Year - b.Year) * 12 + a.Month - b.Month,

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/RoundFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/RoundFunction.cs
@@ -7,5 +7,6 @@ namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
 [KustoImplementation(Keyword = "Functions.Round")]
 internal partial class RoundFunction
 {
-    private static double Impl(double input, long precision) => Math.Round(input, (int)precision);
+    private static double ImplP(double input, long precision) => Math.Round(input, (int)precision);
+    private static double Impl(double input) => Math.Round(input, 0);
 }


### PR DESCRIPTION
- Fix min/max aggregation by datetime
- Allow datetime_diff to have mixed case period specifiers
- Provide single-parameter overload of round 