### PR TITLE
Allows names that include underscores

### DIFF
--- a/libraries/KustoLoco.Core/KustoNameEscaping.cs
+++ b/libraries/KustoLoco.Core/KustoNameEscaping.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 namespace KustoLoco.Core;
 
@@ -43,9 +44,11 @@ public static class KustoNameEscaping
     /// </summary>
     public static string EscapeIfNecessary(string name)
     {
+        bool IsAllowableChar(char c)
+            => Char.IsLetterOrDigit(c) || c == '_';
         name = RemoveFraming(name);
         return name
-            .Any(c => !char.IsLetterOrDigit(c))
+            .Any(c => !IsAllowableChar(c))
             ? EnsureFraming(name)
             : name;
     }

--- a/libraries/lokql-engine/NameEscaper.cs
+++ b/libraries/lokql-engine/NameEscaper.cs
@@ -7,10 +7,6 @@ public static class NameEscaper
 {
     public static string EscapeIfNecessary(string name)
     {
-        name = KustoNameEscaping.RemoveFraming(name);
-        return name
-            .Any(c => !char.IsLetterOrDigit(c))
-            ? KustoNameEscaping.EnsureFraming(name)
-            : name;
+       return  KustoNameEscaping.EscapeIfNecessary(name);
     }
 }

--- a/test/ExtendedCoreTests/EscapingTests.cs
+++ b/test/ExtendedCoreTests/EscapingTests.cs
@@ -1,0 +1,22 @@
+using FluentAssertions;
+using KustoLoco.Core;
+
+namespace ExtendedCoreTests;
+
+[TestClass]
+public class EscapingTests
+{
+    [TestMethod]
+    public void EscapingWorksAsExpected()
+    {
+        KustoNameEscaping.EscapeIfNecessary("abcd").Should().Be("abcd");
+        KustoNameEscaping.EscapeIfNecessary("ab_de_xy").Should().Be("ab_de_xy");
+        KustoNameEscaping.EscapeIfNecessary("a-b").Should().Be("['a-b']");
+        KustoNameEscaping.EscapeIfNecessary("a b").Should().Be("['a b']");
+
+        //pre-escaped
+
+        KustoNameEscaping.EscapeIfNecessary("['abc']").Should().Be("abc");
+        KustoNameEscaping.EscapeIfNecessary("['a b']").Should().Be("['a b']");
+    }
+}


### PR DESCRIPTION
Improve table/column name escaping by allowing names that include underscores to be unescaped