### PR TITLE
Support pagination of KustoQueryResults.

### DIFF
--- a/libraries/KustoLoco.Core/DataSource/ChunkSlicer.cs
+++ b/libraries/KustoLoco.Core/DataSource/ChunkSlicer.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Linq;
+using KustoLoco.Core.Util;
+using NLog;
+
+namespace KustoLoco.Core.DataSource;
+
+/// <summary>
+///     Fetches a subset of a chunk
+/// </summary>
+/// <remarks>
+/// Used to support pagination
+/// </remarks>
+public static class ChunkSlicer
+{
+    public static ITableChunk Slice(ITableChunk source, int start, int chunkSize)
+    {
+        var totalSize = source.Columns[0].RowCount;
+        var offset = Math.Min(start, totalSize);
+        var top = Math.Min(totalSize, start + chunkSize);
+        var takeSize = top - offset;
+        if (takeSize == 0)
+            return CreateEmptyChunk(source);
+        var chunkCols =
+            source.Columns.Select(col => ColumnHelpers.MapColumn(col, offset, takeSize)).ToArray();
+        return new TableChunk(source.Table, chunkCols);
+    }
+
+    public static ITableChunk CreateEmptyChunk(ITableChunk source)
+    {
+        var zeroCols =
+            source.Columns.Select(col => ColumnHelpers.MapColumn(col, 0, 0)).ToArray();
+        return new TableChunk(source.Table, zeroCols);
+    }
+}

--- a/libraries/KustoLoco.Core/DataSource/ChunkSplitter.cs
+++ b/libraries/KustoLoco.Core/DataSource/ChunkSplitter.cs
@@ -6,6 +6,13 @@ using NLog;
 
 namespace KustoLoco.Core.DataSource;
 
+/// <summary>
+/// Splits a single large chunk into multiple smaller chunks
+/// </summary>
+/// <remarks>
+/// Primarily used for testing chunk spanning operations.  There's not really anywhere
+/// in the real codebase where we deliberately split a chunk into smaller chunks
+/// </remarks>
 public static class ChunkSplitter
 {
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();

--- a/libraries/KustoLoco.Core/DataSource/InMemoryTableSource.cs
+++ b/libraries/KustoLoco.Core/DataSource/InMemoryTableSource.cs
@@ -16,7 +16,7 @@ namespace KustoLoco.Core.DataSource;
 /// </summary>
 public class InMemoryTableSource : ITableSource
 {
-    public static readonly InMemoryTableSource Empty = new(TableSymbol.Empty, Array.Empty<BaseColumn>());
+    public static readonly InMemoryTableSource Empty = new(TableSymbol.Empty, []);
 
     //actually only ever one chunk
     private readonly ITableChunk[] _data;
@@ -24,7 +24,7 @@ public class InMemoryTableSource : ITableSource
     public InMemoryTableSource(TableSymbol type, BaseColumn[] columns)
     {
         Type = type;
-        _data = new ITableChunk[] { new TableChunk(this, columns) };
+        _data = [new TableChunk(this, columns)];
     }
 
     public int RowCount => _data.First().RowCount;

--- a/libraries/KustoLoco.Core/Util/ChunkHelpers.cs
+++ b/libraries/KustoLoco.Core/Util/ChunkHelpers.cs
@@ -1,8 +1,12 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using Kusto.Language.Parsing;
 using KustoLoco.Core.DataSource;
 using KustoLoco.Core.DataSource.Columns;
+using KustoLoco.Core.Evaluation;
+using KustoLoco.Core.Extensions;
+using static KustoLoco.Core.Evaluation.TreeEvaluator;
 
 namespace KustoLoco.Core.Util;
 

--- a/libraries/KustoLoco.Core/Util/PageOfKustoTable.cs
+++ b/libraries/KustoLoco.Core/Util/PageOfKustoTable.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Kusto.Language.Symbols;
+using KustoLoco.Core.DataSource;
+
+namespace KustoLoco.Core.Util;
+
+/// <summary>
+/// Represents a page into a table
+/// </summary>
+/// <remarks>
+/// When paginating results it's useful to be able to select a sub-page.
+/// The maths is a little tricky because the source data may be split into chunks that
+/// have sizes that don't correspond to or align with the page size
+/// </remarks>
+public class PageOfKustoTable : ITableSource
+{
+    private readonly int _pageStartOffset;
+    private readonly ITableSource _source;
+    private readonly int pageSize;
+
+    private PageOfKustoTable(ITableSource source, int pageStartOffset, int pageSize)
+    {
+        _source = source;
+        _pageStartOffset = pageStartOffset;
+        this.pageSize = pageSize;
+    }
+
+    public TableSymbol Type => _source.Type;
+
+    public IEnumerable<ITableChunk> GetData()
+    {
+        var chunksReturned = false;
+        var chunkOffset = 0;
+        foreach (var c in _source.GetData())
+        {
+            //if this has no data that overlaps with the required subsection then skip it
+            var chunkIsBeforeRequiredSection = chunkOffset + c.RowCount <= _pageStartOffset;
+            var chunkIsAfterRequiredSection = chunkOffset >= _pageStartOffset + pageSize;
+            if (chunkIsBeforeRequiredSection || chunkIsAfterRequiredSection)
+            {
+                chunkOffset += c.RowCount;
+                continue;
+            }
+            var intersectionStart = Math.Max(chunkOffset, _pageStartOffset) - chunkOffset;
+            var intersectionEnd = Math.Min(chunkOffset + c.RowCount, _pageStartOffset + pageSize) - chunkOffset;
+            var sliced = ChunkSlicer.Slice(c, intersectionStart, intersectionEnd - intersectionStart);
+            chunksReturned = true;
+            yield return sliced;
+        }
+        //ensure that even out of range pages return an empty chunk
+        if (!chunksReturned)
+            yield return ChunkSlicer.CreateEmptyChunk(_source.GetData().First());
+    }
+
+    public IAsyncEnumerable<ITableChunk> GetDataAsync(CancellationToken cancellation = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static ITableSource Create(ITableSource source, int pageStartOffset, int pageSize)
+    {
+        return new PageOfKustoTable(source, pageStartOffset, pageSize);
+    }
+}

--- a/test/BasicTests/ChunkTests.cs
+++ b/test/BasicTests/ChunkTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using KustoLoco.Core;
 using KustoLoco.Core.Console;
 using KustoLoco.Core.DataSource;
+using KustoLoco.Core.Util;
 using LogSetup;
 using NLog;
 
@@ -59,5 +60,75 @@ public class ChunkTests
         AddChunkedTableFromRecords(context, "data", rows, 2);
         var result = (await context.RunQuery("data | where Value < 10 | count"));
         KustoFormatter.Tabulate(result).Should().Contain("10");
+    }
+
+    [TestMethod]
+    public async Task SimplePaging()
+    {
+        var context = CreateContext();
+        var rows = Enumerable.Range(0, 100).Select(i => new Row(i.ToString(), i)).ToArray();
+
+        AddChunkedTableFromRecords(context, "data", rows, 1000);
+        var result = (await context.RunQuery("data | project Value"));
+        var pagedTable = PageOfKustoTable.Create(result.Table,10,20);
+        var resultPage = new KustoQueryResult(result.Query, InMemoryTableSource.FromITableSource(pagedTable),result.Visualization,result.QueryDuration,result.Error);
+        resultPage.Get(0,0).Should().Be(10);
+        resultPage.RowCount.Should().Be(20);
+    }
+
+    [TestMethod]
+    public async Task PagingAcrossChunks()
+    {
+        var context = CreateContext();
+        var rows = Enumerable.Range(0, 100).Select(i => new Row(i.ToString(), i)).ToArray();
+
+        AddChunkedTableFromRecords(context, "data", rows, 3);
+        var result = (await context.RunQuery("data | project Value"));
+        var pagedTable = PageOfKustoTable.Create(result.Table, 10, 20);
+        var resultPage = new KustoQueryResult(result.Query, InMemoryTableSource.FromITableSource(pagedTable), result.Visualization, result.QueryDuration, result.Error);
+        resultPage.Get(0, 0).Should().Be(10);
+        resultPage.RowCount.Should().Be(20);
+        resultPage.Get(0, 19).Should().Be(29);
+    }
+
+    [TestMethod]
+    public async Task PagingBeyondEnd()
+    {
+        var context = CreateContext();
+        var rows = Enumerable.Range(0, 1000).Select(i => new Row(i.ToString(), i)).ToArray();
+
+        AddChunkedTableFromRecords(context, "data", rows, 3);
+        var result = (await context.RunQuery("data | project Value"));
+        var pagedTable = PageOfKustoTable.Create(result.Table, 990, 20);
+        var resultPage = new KustoQueryResult(result.Query, InMemoryTableSource.FromITableSource(pagedTable), result.Visualization, result.QueryDuration, result.Error);
+        resultPage.Get(0, 0).Should().Be(990);
+        resultPage.RowCount.Should().Be(10);
+    }
+
+
+    [TestMethod]
+    public async Task ZeroLengthPage()
+    {
+        var context = CreateContext();
+        var rows = Enumerable.Range(0, 100).Select(i => new Row(i.ToString(), i)).ToArray();
+
+        AddChunkedTableFromRecords(context, "data", rows, 3);
+        var result = (await context.RunQuery("data | project Value"));
+        var pagedTable = PageOfKustoTable.Create(result.Table, 10, 0);
+        var resultPage = new KustoQueryResult(result.Query, InMemoryTableSource.FromITableSource(pagedTable), result.Visualization, result.QueryDuration, result.Error);
+        resultPage.RowCount.Should().Be(0);
+    }
+
+    [TestMethod]
+    public async Task OutOfRangePage()
+    {
+        var context = CreateContext();
+        var rows = Enumerable.Range(0, 100).Select(i => new Row(i.ToString(), i)).ToArray();
+
+        AddChunkedTableFromRecords(context, "data", rows, 3);
+        var result = (await context.RunQuery("data | project Value"));
+        var pagedTable = PageOfKustoTable.Create(result.Table, 1000, 1000);
+        var resultPage = new KustoQueryResult(result.Query, InMemoryTableSource.FromITableSource(pagedTable), result.Visualization, result.QueryDuration, result.Error);
+        resultPage.RowCount.Should().Be(0);
     }
 }


### PR DESCRIPTION
If KustoQueryResults are to be presented to client over the network, it can be useful to paginate them.

This PR supports that by providing a virtualised mechanism based on chunk slicing

