### PR TITLE
Fix issue with summarization of unions

### DIFF
--- a/libraries/CopilotSupport/ChatSession.cs
+++ b/libraries/CopilotSupport/ChatSession.cs
@@ -11,7 +11,7 @@ public class ChatSession
     {
         _chatClient = chatClient;
     }
-    private List<ChatMessage> _history = new List<ChatMessage>();
+    private List<ChatMessage> _history = [];
     public static ChatSession Create(AISettings settings,string systemInstructions)
     {
         var chatClient = OrchestratorMethods.CreateAIChatClient(settings);

--- a/libraries/KustoLoco.Core/DataSource/TableChunk.cs
+++ b/libraries/KustoLoco.Core/DataSource/TableChunk.cs
@@ -10,7 +10,7 @@ namespace KustoLoco.Core.DataSource;
 
 public class TableChunk : ITableChunk
 {
-    public static readonly TableChunk Empty = new(NullTableSource.Instance, Array.Empty<BaseColumn>());
+    public static readonly TableChunk Empty = new(NullTableSource.Instance, []);
 
     public TableChunk(ITableSource table, BaseColumn[] columns)
     {

--- a/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.Expressions.Cast.cs
+++ b/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.Expressions.Cast.cs
@@ -3,10 +3,9 @@
 
 using System;
 using System.Diagnostics;
-using KustoLoco.Core.InternalRepresentation;
-using KustoLoco.Core.Util;
 using Kusto.Language.Symbols;
 using KustoLoco.Core.InternalRepresentation.Nodes.Expressions;
+using KustoLoco.Core.Util;
 
 namespace KustoLoco.Core.Evaluation;
 
@@ -101,6 +100,6 @@ internal partial class TreeEvaluator
 
         var expressionResult = node.Expression.Accept(this, context);
         Debug.Assert(expressionResult != null);
-        return impl(new[] { expressionResult });
+        return impl([expressionResult]);
     }
 }

--- a/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.Expressions.cs
+++ b/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.Expressions.cs
@@ -4,12 +4,11 @@
 using System;
 using System.Diagnostics;
 using System.Text.Json.Nodes;
-using KustoLoco.Core.InternalRepresentation;
-using KustoLoco.Core.Util;
 using Kusto.Language.Symbols;
 using KustoLoco.Core.DataSource;
 using KustoLoco.Core.DataSource.Columns;
 using KustoLoco.Core.InternalRepresentation.Nodes.Expressions;
+using KustoLoco.Core.Util;
 
 namespace KustoLoco.Core.Evaluation;
 
@@ -61,9 +60,7 @@ internal partial class TreeEvaluator
 
             var data = new JsonNode?[itemsCol.RowCount];
             for (var i = 0; i < items.Column.RowCount; i++)
-            {
                 data[i] = IndexIntoPossibleJsonArray(itemsCol[i], node.Index);
-            }
 
             var column = new InMemoryColumn<JsonNode?>(data);
             return new ColumnarResult(column);
@@ -110,8 +107,10 @@ internal partial class TreeEvaluator
     }
 
     public override EvaluationResult
-        VisitLiteralExpression(IRLiteralExpressionNode node, EvaluationContext context) =>
-        new ScalarResult(node.ResultType, node.Value);
+        VisitLiteralExpression(IRLiteralExpressionNode node, EvaluationContext context)
+    {
+        return new ScalarResult(node.ResultType, node.Value);
+    }
 
     public override EvaluationResult VisitPipeExpression(IRPipeExpressionNode node, EvaluationContext context)
     {

--- a/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.Range.cs
+++ b/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.Range.cs
@@ -6,260 +6,266 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.Threading;
-using KustoLoco.Core.InternalRepresentation;
 using Kusto.Language.Symbols;
 using KustoLoco.Core.DataSource;
-using KustoLoco.Core.DataSource.Columns;
 using KustoLoco.Core.InternalRepresentation.Nodes.Expressions.QueryOperators;
 
-namespace KustoLoco.Core.Evaluation
+namespace KustoLoco.Core.Evaluation;
+
+internal partial class TreeEvaluator
 {
-    internal partial class TreeEvaluator
+    private const int MaxRowsPerChunk = 100_000;
+
+    public override EvaluationResult VisitRangeOperator(IRRangeOperatorNode node, EvaluationContext context)
     {
-        private const int MaxRowsPerChunk = 100_000;
+        var fromExpressionResult = (ScalarResult)node.FromExpression.Accept(this, context);
+        var toExpressionResult = (ScalarResult)node.ToExpression.Accept(this, context);
+        var stepExpressionResult = (ScalarResult)node.StepExpression.Accept(this, context);
 
-        public override EvaluationResult VisitRangeOperator(IRRangeOperatorNode node, EvaluationContext context)
+        var resultType = (TableSymbol)node.ResultType;
+
+        var result = CreateTable(fromExpressionResult, toExpressionResult, stepExpressionResult, resultType);
+        return TabularResult.CreateUnvisualized(result);
+
+        // Local function
+        static ITableSource CreateTable(ScalarResult from, ScalarResult to, ScalarResult step,
+            TableSymbol resultType)
         {
-            var fromExpressionResult = (ScalarResult)node.FromExpression.Accept(this, context);
-            var toExpressionResult = (ScalarResult)node.ToExpression.Accept(this, context);
-            var stepExpressionResult = (ScalarResult)node.StepExpression.Accept(this, context);
+            var columnType = resultType.Columns[0].Type!;
 
-            var resultType = (TableSymbol)node.ResultType;
+            if (columnType == ScalarTypes.Long)
+                return new RangeResultTable<long>(from, to, step, resultType);
 
-            var result = CreateTable(fromExpressionResult, toExpressionResult, stepExpressionResult, resultType);
-            return TabularResult.CreateUnvisualized(result);
+            if (columnType == ScalarTypes.Int)
+                return new RangeResultTable<int>(from, to, step, resultType);
 
-            // Local function
-            static ITableSource CreateTable(ScalarResult from, ScalarResult to, ScalarResult step,
-                TableSymbol resultType)
+            if (columnType == ScalarTypes.Real)
+                return new RangeResultTable<double>(from, to, step, resultType);
+            if (columnType == ScalarTypes.TimeSpan)
+                return new RangeResultTableForTimeSpan(from, to, step, resultType);
+
+            if (columnType == ScalarTypes.DateTime)
+                return new RangeResultTableForDateTime(from, to, step, resultType);
+
+            throw new NotImplementedException($"Range operator not implemented for type: {columnType}");
+        }
+    }
+
+    private static T GetValue<T>(object value)
+    {
+        return (T)Convert.ChangeType(value, typeof(T));
+    }
+
+    private class RangeResultTable<T> : ITableSource
+        where T : struct, INumber<T>
+    {
+        private readonly T _from;
+        private readonly T _step;
+        private readonly T _to;
+
+        public RangeResultTable(ScalarResult from, ScalarResult to, ScalarResult step, TableSymbol resultType)
+        {
+            Type = resultType;
+            if (from.Value is null || to.Value is null || step.Value is null)
             {
-                var columnType = resultType.Columns[0].Type!;
-
-                if (columnType == ScalarTypes.Long)
-                    return new RangeResultTable<long>(from, to, step, resultType);
-
-                if (columnType == ScalarTypes.Int)
-                    return new RangeResultTable<int>(from, to, step, resultType);
-
-                if (columnType == ScalarTypes.Real)
-                    return new RangeResultTable<double>(from, to, step, resultType);
-                if (columnType == ScalarTypes.TimeSpan)
-                    return new RangeResultTableForTimeSpan(from, to, step, resultType);
-
-                if (columnType == ScalarTypes.DateTime)
-                    return new RangeResultTableForDateTime(from, to, step, resultType);
-
-                throw new NotImplementedException($"Range operator not implemented for type: {columnType}");
+                // Return empty table
+                _from = T.One;
+                _to = T.Zero;
+                _step = T.One;
+                return;
             }
+
+            _from = GetValue<T>(from.Value);
+            _to = GetValue<T>(to.Value);
+            _step = GetValue<T>(step.Value);
         }
 
-        private static T GetValue<T>(object value) => (T)Convert.ChangeType(value, typeof(T));
+        public TableSymbol Type { get; }
 
-        private class RangeResultTable<T> : ITableSource
-            where T : struct, INumber<T>
+        public IEnumerable<ITableChunk> GetData()
         {
-            private readonly T _from;
-            private readonly T _step;
-            private readonly T _to;
+            var direction = _to >= _from ? T.One : -T.One;
+            var stepDirection = _step >= T.Zero ? T.One : -T.One;
 
-            public RangeResultTable(ScalarResult from, ScalarResult to, ScalarResult step, TableSymbol resultType)
+            if (_step == T.Zero || direction != stepDirection)
             {
-                Type = resultType;
-                if (from.Value is null || to.Value is null || step.Value is null)
-                {
-                    // Return empty table
-                    _from = T.One;
-                    _to = T.Zero;
-                    _step = T.One;
-                    return;
-                }
-
-                _from = GetValue<T>(from.Value);
-                _to = GetValue<T>(to.Value);
-                _step = GetValue<T>(step.Value);
+                yield return new TableChunk(this,
+                    [ColumnFactory.Create(Array.Empty<T?>())]);
+                yield break;
             }
 
-            public TableSymbol Type { get; }
+            Func<T, bool> isDone = direction == T.One
+                ? val => val <= _to
+                : val => val >= _to;
 
-            public IEnumerable<ITableChunk> GetData()
+            var chunk = new T?[MaxRowsPerChunk];
+            var i = 0;
+            for (var val = _from; isDone(val); val += _step)
             {
-                var direction = _to >= _from ? T.One : -T.One;
-                var stepDirection = _step >= T.Zero ? T.One : -T.One;
+                chunk[i++] = val;
 
-                if (_step == T.Zero || direction != stepDirection)
-                {
-                    yield return new TableChunk(this,
-                        new BaseColumn[] { ColumnFactory.Create(Array.Empty<T?>()) });
-                    yield break;
-                }
+                if (i != MaxRowsPerChunk)
+                    continue;
 
-                Func<T, bool> isDone = direction == T.One
-                    ? val => val <= _to
-                    : val => val >= _to;
-
-                var chunk = new T?[MaxRowsPerChunk];
-                var i = 0;
-                for (var val = _from; isDone(val); val += _step)
-                {
-                    chunk[i++] = val;
-
-                    if (i != MaxRowsPerChunk)
-                        continue;
-
-                    yield return new TableChunk(this, new BaseColumn[] { ColumnFactory.Create(chunk) });
-                    i = 0;
-                }
-
-                if (i <= 0)
-                    yield break;
-
-                // Smaller end chunk
-                Array.Resize(ref chunk, i);
-
-                yield return new TableChunk(this, new BaseColumn[] { ColumnFactory.Create(chunk) });
+                yield return new TableChunk(this, [ColumnFactory.Create(chunk)]);
+                i = 0;
             }
 
-            public IAsyncEnumerable<ITableChunk> GetDataAsync(
-                CancellationToken cancellation = default)
-                => GetData().ToAsyncEnumerable();
+            if (i <= 0)
+                yield break;
+
+            // Smaller end chunk
+            Array.Resize(ref chunk, i);
+
+            yield return new TableChunk(this, [ColumnFactory.Create(chunk)]);
         }
 
-        private class RangeResultTableForTimeSpan : ITableSource
+        public IAsyncEnumerable<ITableChunk> GetDataAsync(
+            CancellationToken cancellation = default)
         {
-            private readonly TimeSpan _from;
-            private readonly TimeSpan _step;
-            private readonly TimeSpan _to;
+            return GetData().ToAsyncEnumerable();
+        }
+    }
 
-            public RangeResultTableForTimeSpan(ScalarResult from, ScalarResult to, ScalarResult step,
-                TableSymbol resultType)
+    private class RangeResultTableForTimeSpan : ITableSource
+    {
+        private readonly TimeSpan _from;
+        private readonly TimeSpan _step;
+        private readonly TimeSpan _to;
+
+        public RangeResultTableForTimeSpan(ScalarResult from, ScalarResult to, ScalarResult step,
+            TableSymbol resultType)
+        {
+            Type = resultType;
+            if (from.Value is null || to.Value is null || step.Value is null)
             {
-                Type = resultType;
-                if (from.Value is null || to.Value is null || step.Value is null)
-                {
-                    // Return empty table
-                    _from = TimeSpan.Zero;
-                    _to = TimeSpan.Zero;
-                    _step = TimeSpan.MaxValue;
-                    return;
-                }
-
-                _from = GetValue<TimeSpan>(from.Value);
-                _to = GetValue<TimeSpan>(to.Value);
-                _step = GetValue<TimeSpan>(step.Value);
+                // Return empty table
+                _from = TimeSpan.Zero;
+                _to = TimeSpan.Zero;
+                _step = TimeSpan.MaxValue;
+                return;
             }
 
-            public TableSymbol Type { get; }
-
-            public IEnumerable<ITableChunk> GetData()
-            {
-                var direction = _to >= _from ? 1 : -1;
-                var stepDirection = _step >= TimeSpan.Zero ? 1 : -1;
-
-                if (_step == TimeSpan.Zero || direction != stepDirection)
-                {
-                    yield return new TableChunk(this,
-                        new BaseColumn[] { ColumnFactory.Create(Array.Empty<DateTime?>()) });
-                    yield break;
-                }
-
-                Func<TimeSpan, bool> isDone = direction == 1
-                    ? val => val <= _to
-                    : val => val >= _to;
-
-                var chunk = new TimeSpan?[MaxRowsPerChunk];
-                var i = 0;
-                for (var val = _from; isDone(val); val += _step)
-                {
-                    chunk[i++] = val;
-
-                    if (i != MaxRowsPerChunk)
-                        continue;
-
-                    yield return new TableChunk(this, new BaseColumn[] { ColumnFactory.Create(chunk) });
-                    i = 0;
-                }
-
-                if (i <= 0)
-                    yield break;
-
-                // Smaller end chunk
-                Array.Resize(ref chunk, i);
-
-                yield return new TableChunk(this, new BaseColumn[] { ColumnFactory.Create(chunk) });
-            }
-
-            public IAsyncEnumerable<ITableChunk> GetDataAsync(
-                CancellationToken cancellation = default)
-                => GetData().ToAsyncEnumerable();
+            _from = GetValue<TimeSpan>(from.Value);
+            _to = GetValue<TimeSpan>(to.Value);
+            _step = GetValue<TimeSpan>(step.Value);
         }
 
-        private class RangeResultTableForDateTime : ITableSource
+        public TableSymbol Type { get; }
+
+        public IEnumerable<ITableChunk> GetData()
         {
-            private readonly DateTime _from;
-            private readonly TimeSpan _step;
-            private readonly DateTime _to;
+            var direction = _to >= _from ? 1 : -1;
+            var stepDirection = _step >= TimeSpan.Zero ? 1 : -1;
 
-            public RangeResultTableForDateTime(ScalarResult from, ScalarResult to, ScalarResult step,
-                TableSymbol resultType)
+            if (_step == TimeSpan.Zero || direction != stepDirection)
             {
-                Type = resultType;
-                if (from.Value is null || to.Value is null || step.Value is null)
-                {
-                    // Return empty table
-                    _from = DateTime.MinValue;
-                    _to = DateTime.MinValue;
-                    _step = TimeSpan.MaxValue;
-                    return;
-                }
-
-                _from = GetValue<DateTime>(from.Value);
-                _to = GetValue<DateTime>(to.Value);
-                _step = GetValue<TimeSpan>(step.Value);
+                yield return new TableChunk(this,
+                    [ColumnFactory.Create(Array.Empty<DateTime?>())]);
+                yield break;
             }
 
-            public TableSymbol Type { get; }
+            Func<TimeSpan, bool> isDone = direction == 1
+                ? val => val <= _to
+                : val => val >= _to;
 
-            public IEnumerable<ITableChunk> GetData()
+            var chunk = new TimeSpan?[MaxRowsPerChunk];
+            var i = 0;
+            for (var val = _from; isDone(val); val += _step)
             {
-                var direction = _to >= _from ? 1 : -1;
-                var stepDirection = _step >= TimeSpan.Zero ? 1 : -1;
+                chunk[i++] = val;
 
-                if (_step == TimeSpan.Zero || direction != stepDirection)
-                {
-                    yield return new TableChunk(this,
-                        new BaseColumn[] { ColumnFactory.Create(Array.Empty<DateTime?>()) });
-                    yield break;
-                }
+                if (i != MaxRowsPerChunk)
+                    continue;
 
-                Func<DateTime, bool> isDone = direction == 1
-                    ? val => val <= _to
-                    : val => val >= _to;
-
-                var chunk = new DateTime?[MaxRowsPerChunk];
-                var i = 0;
-                for (var val = _from; isDone(val); val += _step)
-                {
-                    chunk[i++] = val;
-
-                    if (i != MaxRowsPerChunk)
-                        continue;
-
-                    yield return new TableChunk(this, new BaseColumn[] { ColumnFactory.Create(chunk) });
-                    i = 0;
-                }
-
-                if (i <= 0)
-                    yield break;
-
-                // Smaller end chunk
-                Array.Resize(ref chunk, i);
-
-                yield return new TableChunk(this, new BaseColumn[] { ColumnFactory.Create(chunk) });
+                yield return new TableChunk(this, [ColumnFactory.Create(chunk)]);
+                i = 0;
             }
 
-            public IAsyncEnumerable<ITableChunk> GetDataAsync(
-                CancellationToken cancellation = default)
-                => GetData().ToAsyncEnumerable();
+            if (i <= 0)
+                yield break;
+
+            // Smaller end chunk
+            Array.Resize(ref chunk, i);
+
+            yield return new TableChunk(this, [ColumnFactory.Create(chunk)]);
+        }
+
+        public IAsyncEnumerable<ITableChunk> GetDataAsync(
+            CancellationToken cancellation = default)
+        {
+            return GetData().ToAsyncEnumerable();
+        }
+    }
+
+    private class RangeResultTableForDateTime : ITableSource
+    {
+        private readonly DateTime _from;
+        private readonly TimeSpan _step;
+        private readonly DateTime _to;
+
+        public RangeResultTableForDateTime(ScalarResult from, ScalarResult to, ScalarResult step,
+            TableSymbol resultType)
+        {
+            Type = resultType;
+            if (from.Value is null || to.Value is null || step.Value is null)
+            {
+                // Return empty table
+                _from = DateTime.MinValue;
+                _to = DateTime.MinValue;
+                _step = TimeSpan.MaxValue;
+                return;
+            }
+
+            _from = GetValue<DateTime>(from.Value);
+            _to = GetValue<DateTime>(to.Value);
+            _step = GetValue<TimeSpan>(step.Value);
+        }
+
+        public TableSymbol Type { get; }
+
+        public IEnumerable<ITableChunk> GetData()
+        {
+            var direction = _to >= _from ? 1 : -1;
+            var stepDirection = _step >= TimeSpan.Zero ? 1 : -1;
+
+            if (_step == TimeSpan.Zero || direction != stepDirection)
+            {
+                yield return new TableChunk(this,
+                    [ColumnFactory.Create(Array.Empty<DateTime?>())]);
+                yield break;
+            }
+
+            Func<DateTime, bool> isDone = direction == 1
+                ? val => val <= _to
+                : val => val >= _to;
+
+            var chunk = new DateTime?[MaxRowsPerChunk];
+            var i = 0;
+            for (var val = _from; isDone(val); val += _step)
+            {
+                chunk[i++] = val;
+
+                if (i != MaxRowsPerChunk)
+                    continue;
+
+                yield return new TableChunk(this, [ColumnFactory.Create(chunk)]);
+                i = 0;
+            }
+
+            if (i <= 0)
+                yield break;
+
+            // Smaller end chunk
+            Array.Resize(ref chunk, i);
+
+            yield return new TableChunk(this, [ColumnFactory.Create(chunk)]);
+        }
+
+        public IAsyncEnumerable<ITableChunk> GetDataAsync(
+            CancellationToken cancellation = default)
+        {
+            return GetData().ToAsyncEnumerable();
         }
     }
 }

--- a/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.SortResultTable.cs
+++ b/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.SortResultTable.cs
@@ -37,10 +37,10 @@ internal partial class TreeEvaluator
         public IEnumerable<ITableChunk> GetData()
         {
             var allData = new List<object?>[_input.Type.Columns.Count];
-            for (var i = 0; i < allData.Length; i++) allData[i] = new List<object?>();
+            for (var i = 0; i < allData.Length; i++) allData[i] = [];
 
             var sortColumnsData = new List<object?>[_sortColumns.Length];
-            for (var i = 0; i < _sortColumns.Length; i++) sortColumnsData[i] = new List<object?>();
+            for (var i = 0; i < _sortColumns.Length; i++) sortColumnsData[i] = [];
 
             foreach (var chunk in _input.GetData())
             {
@@ -82,7 +82,8 @@ internal partial class TreeEvaluator
             for (var i = 0; i < resultColumns.Length; i++)
             {
                 resultColumns[i] = ColumnHelpers.CreateBuilder(_input.Type.Columns[i].Type);
-                for (var j = 0; j < sortedIndexes.Length; j++) resultColumns[i].Add(allData[i][sortedIndexes[j]]);
+                foreach (var t in sortedIndexes)
+                    resultColumns[i].Add(allData[i][t]);
             }
 
             var resultChunk = new TableChunk(this, resultColumns.Select(c => c.ToColumn()).ToArray());

--- a/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.Count.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.Count.cs
@@ -1,12 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections.Generic;
-using KustoLoco.Core.Evaluation.BuiltIns;
 using Kusto.Language;
 using Kusto.Language.Symbols;
 using Kusto.Language.Syntax;
+using KustoLoco.Core.Evaluation.BuiltIns;
 using KustoLoco.Core.InternalRepresentation.Nodes.Expressions;
 using KustoLoco.Core.InternalRepresentation.Nodes.Expressions.QueryOperators;
 
@@ -21,12 +20,12 @@ internal partial class IRTranslator
         {
             new IRAggregateCallNode(
                 Aggregates.Count.Signatures[0],
-                BuiltInAggregates.GetOverload(Aggregates.Count, Array.Empty<IRExpressionNode>(), new List<Parameter>()),
+                BuiltInAggregates.GetOverload(Aggregates.Count, [], []),
                 new List<Parameter>(),
                 IRListNode<IRExpressionNode>.Empty,
-                ScalarTypes.Long),
+                ScalarTypes.Long)
         };
-        return new IRSummarizeOperatorNode(aggregations: IRListNode.From(aggregations),
-            byColumns: IRListNode<IRExpressionNode>.Empty, node.ResultType);
+        return new IRSummarizeOperatorNode(IRListNode.From(aggregations),
+            IRListNode<IRExpressionNode>.Empty, node.ResultType);
     }
 }

--- a/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.Join.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.Join.cs
@@ -10,6 +10,7 @@ using Kusto.Language.Syntax;
 using Kusto.Language.Utils;
 using KustoLoco.Core.InternalRepresentation.Nodes.Expressions;
 using KustoLoco.Core.InternalRepresentation.Nodes.Expressions.QueryOperators;
+// ReSharper disable StringLiteralTypo
 
 
 namespace KustoLoco.Core.InternalRepresentation;
@@ -56,7 +57,7 @@ internal partial class IRTranslator
                 $"Expected join operator's Right type to be tabular, found {SchemaDisplay.GetText(irExpression.ResultType)}");
         }
 
-        List<IRJoinOnClause> onExpressions = new();
+        List<IRJoinOnClause> onExpressions = [];
         if (node.ConditionClause is JoinOnClause onClause)
         {
             Debug.Assert(_rowScope != TableSymbol.Empty);

--- a/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.Summarize.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.Summarize.cs
@@ -13,7 +13,7 @@ internal partial class IRTranslator
 {
     public override IRNode VisitSummarizeOperator(SummarizeOperator node)
     {
-        List<IRExpressionNode> byColumns = new();
+        List<IRExpressionNode> byColumns = [];
         if (node.ByClause != null)
         {
             var byExpressionsCount = node.ByClause.Expressions.Count;

--- a/libraries/KustoLoco.Core/TableBuilder.cs
+++ b/libraries/KustoLoco.Core/TableBuilder.cs
@@ -37,8 +37,8 @@ public class TableBuilder
     private TableBuilder(string name, IEnumerable<BaseColumn> columns,
         IEnumerable<string> columnNames, int length)
     {
-        _columns = columns.ToImmutableArray();
-        _columnNames = columnNames.ToImmutableArray();
+        _columns = [..columns];
+        _columnNames = [..columnNames];
         Length = length;
         Name = name;
     }

--- a/libraries/KustoLoco.Core/Util/ColumnBuilder.cs
+++ b/libraries/KustoLoco.Core/Util/ColumnBuilder.cs
@@ -11,7 +11,7 @@ namespace KustoLoco.Core.Util;
 
 public class ColumnBuilder<T> : BaseColumnBuilder
 {
-    private readonly List<T?> _data = new();
+    private readonly List<T?> _data = [];
 
     public override int RowCount => _data.Count;
     public override object? this[int index] => _data[index];

--- a/libraries/KustoLoco.Core/Util/ColumnHelpers.cs
+++ b/libraries/KustoLoco.Core/Util/ColumnHelpers.cs
@@ -188,13 +188,13 @@ public static class ColumnHelpers
     {
         //TODO - packing the offset and length into a mapping array is just a bit of 
         //a hack to make the internal API easier
-        return MapColumn(new[] { other }, new[] { offset, length }.ToImmutableArray(),
+        return MapColumn([other], [..new[] { offset, length }],
             MappingType.Chunk);
     }
 
     public static BaseColumn MapColumn(BaseColumn other, ImmutableArray<int> mapping)
     {
-        return MapColumn(new[] { other }, mapping, MappingType.Arbitrary);
+        return MapColumn([other], mapping, MappingType.Arbitrary);
     }
 
     public static BaseColumn ReassembleInOrder(BaseColumn[] others)

--- a/libraries/lokql-engine/BlockInterpolator.cs
+++ b/libraries/lokql-engine/BlockInterpolator.cs
@@ -7,7 +7,7 @@ public class BlockInterpolator
 {
 
 
-    private readonly List<KustoSettingsProvider> _settingsStack = new List<KustoSettingsProvider>();
+    private readonly List<KustoSettingsProvider> _settingsStack = [];
     public BlockInterpolator(KustoSettingsProvider coreSettings)
     {
         _settingsStack.Add(coreSettings);
@@ -24,7 +24,9 @@ public class BlockInterpolator
 
     public string Interpolate(string query)
     {
-        string rep(Match m)
+        return Regex.Replace(query, @"\$?\$(\(?)([a-zA-Z0-9_\.]+)(\)?)", ReplaceVar);
+
+        string ReplaceVar(Match m)
         {
             var fullMatch =m.Value;
             if(fullMatch.StartsWith("$$"))
@@ -43,7 +45,5 @@ public class BlockInterpolator
             }
             return fullMatch;
         }
-
-        return Regex.Replace(query, @"\$?\$(\(?)([a-zA-Z0-9_\.]+)(\)?)", rep);
     }
 }

--- a/samples/Blazor-Server/Components/Pages/SettingsPage.razor
+++ b/samples/Blazor-Server/Components/Pages/SettingsPage.razor
@@ -162,17 +162,14 @@
     private string ApiVersion = "";
 
     // Collections
-    private readonly List<string> colAITypes = new()
-    {
+    private readonly List<string> colAITypes =
+    [
         "OpenAI",
         "Azure OpenAI",
         "Local LLM"
-    };
+    ];
 
-    private readonly List<string> colModels = new()
-    {
-        "gpt-4o", "gpt-4o-mini", "gpt-4-turbo"
-    };
+    private readonly List<string> colModels = ["gpt-4o", "gpt-4o-mini", "gpt-4-turbo"];
 
     protected override async Task OnInitializedAsync()
     {

--- a/samples/WebApp/Controllers/KqlController.cs
+++ b/samples/WebApp/Controllers/KqlController.cs
@@ -8,10 +8,10 @@ namespace WebApp.Controllers
     [Route("[controller]")]
     public class KqlController : ControllerBase
     {
-        private static readonly string[] Summaries = new[]
-        {
+        private static readonly string[] Summaries =
+        [
             "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-        };
+        ];
 
         private readonly ILogger<KqlController> _logger;
         private readonly KustoQueryContext context;

--- a/test/BasicTests/ChunkTests.cs
+++ b/test/BasicTests/ChunkTests.cs
@@ -15,10 +15,10 @@ public class ChunkTests
         LoggingExtensions.SetupLoggingForTest(LogLevel.Trace);
     }
 
-    private static KustoQueryContext CreateContext()
-        => KustoQueryContext.CreateForTest();
+    private static KustoQueryContext CreateContext() => KustoQueryContext.CreateForTest();
 
-    private void AddChunkedTableFromRecords<T>(KustoQueryContext context,string tableName, IReadOnlyCollection<T> records, int chunkSize)
+    private void AddChunkedTableFromRecords<T>(KustoQueryContext context, string tableName,
+        IReadOnlyCollection<T> records, int chunkSize)
     {
         var table = TableBuilder.CreateFromVolatileData(tableName, records);
         var chunked = ChunkedKustoTable
@@ -32,12 +32,12 @@ public class ChunkTests
         var context = CreateContext();
         var rows = Enumerable.Range(0, 20).Select(i => new Row(i.ToString(), i)).ToArray();
 
-        AddChunkedTableFromRecords(context,"data", rows, 2);
-        var result = (await context.RunQuery("data | take 5"));
+        AddChunkedTableFromRecords(context, "data", rows, 2);
+        var result = await context.RunQuery("data | take 5");
         result.RowCount.Should().Be(5);
         //TODO - here compare tabulated output for more coverage
     }
-    
+
 
     [TestMethod]
     public async Task Count()
@@ -45,8 +45,8 @@ public class ChunkTests
         var context = CreateContext();
         var rows = Enumerable.Range(0, 20).Select(i => new Row(i.ToString(), i)).ToArray();
 
-        AddChunkedTableFromRecords(context,"data", rows, 2);
-        var result = (await context.RunQuery("data | count"));
+        AddChunkedTableFromRecords(context, "data", rows, 2);
+        var result = await context.RunQuery("data | count");
         KustoFormatter.Tabulate(result).Should().Contain("20");
     }
 
@@ -57,7 +57,7 @@ public class ChunkTests
         var rows = Enumerable.Range(0, 20).Select(i => new Row(i.ToString(), i)).ToArray();
 
         AddChunkedTableFromRecords(context, "data", rows, 2);
-        var result = (await context.RunQuery("data | where Value < 10 | count"));
+        var result = await context.RunQuery("data | where Value < 10 | count");
         KustoFormatter.Tabulate(result).Should().Contain("10");
     }
 
@@ -68,10 +68,11 @@ public class ChunkTests
         var rows = Enumerable.Range(0, 100).Select(i => new Row(i.ToString(), i)).ToArray();
 
         AddChunkedTableFromRecords(context, "data", rows, 1000);
-        var result = (await context.RunQuery("data | project Value"));
-        var pagedTable = PageOfKustoTable.Create(result.Table,10,20);
-        var resultPage = new KustoQueryResult(result.Query, InMemoryTableSource.FromITableSource(pagedTable),result.Visualization,result.QueryDuration,result.Error);
-        resultPage.Get(0,0).Should().Be(10);
+        var result = await context.RunQuery("data | project Value");
+        var pagedTable = PageOfKustoTable.Create(result.Table, 10, 20);
+        var resultPage = new KustoQueryResult(result.Query, InMemoryTableSource.FromITableSource(pagedTable),
+            result.Visualization, result.QueryDuration, result.Error);
+        resultPage.Get(0, 0).Should().Be(10);
         resultPage.RowCount.Should().Be(20);
     }
 
@@ -82,9 +83,10 @@ public class ChunkTests
         var rows = Enumerable.Range(0, 100).Select(i => new Row(i.ToString(), i)).ToArray();
 
         AddChunkedTableFromRecords(context, "data", rows, 3);
-        var result = (await context.RunQuery("data | project Value"));
+        var result = await context.RunQuery("data | project Value");
         var pagedTable = PageOfKustoTable.Create(result.Table, 10, 20);
-        var resultPage = new KustoQueryResult(result.Query, InMemoryTableSource.FromITableSource(pagedTable), result.Visualization, result.QueryDuration, result.Error);
+        var resultPage = new KustoQueryResult(result.Query, InMemoryTableSource.FromITableSource(pagedTable),
+            result.Visualization, result.QueryDuration, result.Error);
         resultPage.Get(0, 0).Should().Be(10);
         resultPage.RowCount.Should().Be(20);
         resultPage.Get(0, 19).Should().Be(29);
@@ -97,9 +99,10 @@ public class ChunkTests
         var rows = Enumerable.Range(0, 1000).Select(i => new Row(i.ToString(), i)).ToArray();
 
         AddChunkedTableFromRecords(context, "data", rows, 3);
-        var result = (await context.RunQuery("data | project Value"));
+        var result = await context.RunQuery("data | project Value");
         var pagedTable = PageOfKustoTable.Create(result.Table, 990, 20);
-        var resultPage = new KustoQueryResult(result.Query, InMemoryTableSource.FromITableSource(pagedTable), result.Visualization, result.QueryDuration, result.Error);
+        var resultPage = new KustoQueryResult(result.Query, InMemoryTableSource.FromITableSource(pagedTable),
+            result.Visualization, result.QueryDuration, result.Error);
         resultPage.Get(0, 0).Should().Be(990);
         resultPage.RowCount.Should().Be(10);
     }
@@ -112,9 +115,10 @@ public class ChunkTests
         var rows = Enumerable.Range(0, 100).Select(i => new Row(i.ToString(), i)).ToArray();
 
         AddChunkedTableFromRecords(context, "data", rows, 3);
-        var result = (await context.RunQuery("data | project Value"));
+        var result = await context.RunQuery("data | project Value");
         var pagedTable = PageOfKustoTable.Create(result.Table, 10, 0);
-        var resultPage = new KustoQueryResult(result.Query, InMemoryTableSource.FromITableSource(pagedTable), result.Visualization, result.QueryDuration, result.Error);
+        var resultPage = new KustoQueryResult(result.Query, InMemoryTableSource.FromITableSource(pagedTable),
+            result.Visualization, result.QueryDuration, result.Error);
         resultPage.RowCount.Should().Be(0);
     }
 
@@ -125,9 +129,10 @@ public class ChunkTests
         var rows = Enumerable.Range(0, 100).Select(i => new Row(i.ToString(), i)).ToArray();
 
         AddChunkedTableFromRecords(context, "data", rows, 3);
-        var result = (await context.RunQuery("data | project Value"));
+        var result = await context.RunQuery("data | project Value");
         var pagedTable = PageOfKustoTable.Create(result.Table, 1000, 1000);
-        var resultPage = new KustoQueryResult(result.Query, InMemoryTableSource.FromITableSource(pagedTable), result.Visualization, result.QueryDuration, result.Error);
+        var resultPage = new KustoQueryResult(result.Query, InMemoryTableSource.FromITableSource(pagedTable),
+            result.Visualization, result.QueryDuration, result.Error);
         resultPage.RowCount.Should().Be(0);
     }
 
@@ -136,13 +141,51 @@ public class ChunkTests
     {
         var context = CreateContext();
         var rows = Enumerable.Range(0, 100).Select(i => new Row(i.ToString(), i)).ToArray();
-        
+
         AddChunkedTableFromRecords(context, "data", rows, 3);
-        var result = (await context.RunQuery("data | project Value"));
+        var result = await context.RunQuery("data | project Value");
         context.MaterializeResultAsTable(result, "res");
 
-        result = (await context.RunQuery("res | take 10"));
+        result = await context.RunQuery("res | take 10");
         result.RowCount.Should().Be(10);
+    }
 
+    [TestMethod]
+    public async Task SimplestUnion()
+    {
+        //create two single-row tables and use union to join them
+        var context = CreateContext();
+        var rows = Enumerable.Range(0, 2).Select(i => new Row(i.ToString(), i)).ToArray();
+
+        AddChunkedTableFromRecords(context, "table1", [rows[0]], 100);
+        AddChunkedTableFromRecords(context, "table2", [rows[1]], 100);
+        var result = await context.RunQuery("table1 | union table2 | summarize count() by Name | project count_");
+        // Since the ids are unique, we shoudl have two rows each of count 1
+        result.RowCount.Should().Be(2);
+        foreach (var row in result.EnumerateRows()) row[0].Should().Be(1);
+    }
+
+    [TestMethod]
+    public async Task SimpleUnionWithChunkSpanningTables()
+    {
+        //create a couple of multi-chunk tables that we're going to combine with the
+        //union operator
+        var context = CreateContext();
+        var rows = Enumerable.Range(0, 100).Select(i => new Row(i.ToString(), i)).ToArray();
+
+        AddChunkedTableFromRecords(context, "table1", rows, 3);
+        AddChunkedTableFromRecords(context, "table2", rows, 5);
+        var result = await context.RunQuery("table1 | union table2");
+        result.RowCount.Should().Be(rows.Length * 2);
+
+        result = await context.RunQuery("table1 | union table2 | count");
+        result.Get(0, 0).Should().Be(rows.Length * 2);
+
+        result = await context.RunQuery("table1 | union table2 | summarize count()");
+        result.Get(0, 0).Should().Be(rows.Length * 2);
+
+        result = await context.RunQuery("table1 | union table2 | summarize count() by Name | project count_");
+        //we've used the same set of ids in each table so the count for each row should be 2.
+        foreach (var row in result.EnumerateRows()) row[0].Should().Be(2);
     }
 }

--- a/test/CoreTests/Util/TypeSymbolExtensionsTests.cs
+++ b/test/CoreTests/Util/TypeSymbolExtensionsTests.cs
@@ -10,27 +10,27 @@ namespace KustoLoco.Core.Extensions.Tests;
 public class TypeSymbolExtensionsTests
 {
     public static object[][] NonDynamicTypes =
-    {
-        new object[] { ScalarTypes.Bool },
-        new object[] { ScalarTypes.Int },
-        new object[] { ScalarTypes.Long },
-        new object[] { ScalarTypes.Real },
-        new object[] { ScalarTypes.String },
-        new object[] { ScalarTypes.TimeSpan },
-        new object[] { ScalarTypes.DateTime },
-    };
+    [
+        [ScalarTypes.Bool],
+        [ScalarTypes.Int],
+        [ScalarTypes.Long],
+        [ScalarTypes.Real],
+        [ScalarTypes.String],
+        [ScalarTypes.TimeSpan],
+        [ScalarTypes.DateTime]
+    ];
 
     public static object[][] DynamicTypes =
-    {
-        new object[] { ScalarTypes.Dynamic },
-        new object[] { ScalarTypes.DynamicBag },
-        new object[] { ScalarTypes.DynamicArrayOfLong },
-        new object[] { ScalarTypes.DynamicArrayOfReal },
-        new object[] { ScalarTypes.DynamicArrayOfArray },
-        new object[] { ScalarTypes.DynamicArrayOfString },
-        new object[] { ScalarTypes.GetDynamic(ScalarTypes.DateTime) },
-        new object[] { ScalarTypes.GetDynamicArray(ScalarTypes.DateTime) },
-    };
+    [
+        [ScalarTypes.Dynamic],
+        [ScalarTypes.DynamicBag],
+        [ScalarTypes.DynamicArrayOfLong],
+        [ScalarTypes.DynamicArrayOfReal],
+        [ScalarTypes.DynamicArrayOfArray],
+        [ScalarTypes.DynamicArrayOfString],
+        [ScalarTypes.GetDynamic(ScalarTypes.DateTime)],
+        [ScalarTypes.GetDynamicArray(ScalarTypes.DateTime)]
+    ];
 
     [Theory]
     [MemberData(nameof(NonDynamicTypes))]

--- a/test/ExtendedCoreTests/IndirectTests.cs
+++ b/test/ExtendedCoreTests/IndirectTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using FluentAssertions;
 using KustoLoco.Core.DataSource.Columns;
 using KustoLoco.Core.Util;
@@ -14,7 +13,7 @@ public class IndirectTests
             .Select(i => i.ToString()).ToArray();
         var cs = new InMemoryColumn<string>(originalData);
         var backing = MappedColumn<string>.Create(
-            Enumerable.Range(0, sourceCount).Where(i => i % 10 == 0).ToImmutableArray()
+            [..Enumerable.Range(0, sourceCount).Where(i => i % 10 == 0)]
             , cs);
         return (MappedColumn<string>)backing;
     }
@@ -56,17 +55,17 @@ public class IndirectTests
     public void MappedIndirectionFlattens()
     {
         var backing = MakeDecimatedColumn(100);
-        var flattened = ColumnHelpers.MapColumn(backing, new[] { 0, 1 }.ToImmutableArray()) as MappedColumn<string>;
+        var flattened = ColumnHelpers.MapColumn(backing, [..new[] { 0, 1 }]) as MappedColumn<string>;
         flattened!.RowCount.Should().Be(2);
-        flattened!.IndirectIndex(0).Should().Be(backing.IndirectIndex(0));
-        flattened!.IndirectIndex(1).Should().Be(backing.IndirectIndex(1));
+        flattened.IndirectIndex(0).Should().Be(backing.IndirectIndex(0));
+        flattened.IndirectIndex(1).Should().Be(backing.IndirectIndex(1));
     }
 
     [TestMethod]
     public void IndirectingSingleValueColumnReturnsSingleValue()
     {
         var sv = new SingleValueColumn<string>("HELLO", 100);
-        var second = ColumnHelpers.MapColumn(sv, new[] { 0, 1 }.ToImmutableArray());
+        var second = ColumnHelpers.MapColumn(sv, [..new[] { 0, 1 }]);
         second.GetType().Should().Be(typeof(SingleValueColumn<string>));
         second.RowCount.Should().Be(2);
         second.GetRawDataValue(0).Should().Be("HELLO");


### PR DESCRIPTION
Fixes #135 

Summarization of tables formed from unions was broken because the summarization looked across the entire set of keys generated so far rather than just the keys for the current chunk.