### PR TITLE
Make pivot commands a bit less confusing by providing a default tablename

### DIFF
--- a/applications/lokqlDx/SyntaxHighlighting.xml
+++ b/applications/lokqlDx/SyntaxHighlighting.xml
@@ -36,6 +36,7 @@
 			<Word>project-away</Word>
 			<Word>project-keep</Word>
 			<Word>project-rename</Word>
+			<Word>project-reorder</Word>
 			<Word>extend</Word>
 			<Word>summarize</Word>
 			<Word>render</Word>

--- a/libraries/lokql-engine/Commands/PivotColumnsToRowsCommand.cs
+++ b/libraries/lokql-engine/Commands/PivotColumnsToRowsCommand.cs
@@ -39,6 +39,7 @@ public static class PivotColumnsToRowsCommand
 
         var builder = TableBuilder.FromOrderedDictionarySet(o.As, ods);
         exp.GetCurrentContext().AddTable(builder);
+        exp.Info($"Table '{o.As}' now available");
         return Task.CompletedTask;
     }
 
@@ -65,7 +66,7 @@ might be better expressed as
         public string ResultName { get; set; } = string.Empty;
 
         [Option(HelpText = "Name of table into which to project the result")]
-        public string As { get; set; } = string.Empty;
+        public string As { get; set; } = "pivot";
 
         [Option(Required=true,HelpText = "Columns to move into rows")]
         public IEnumerable<string> Columns { get; set; } = [];

--- a/libraries/lokql-engine/Commands/PivotRowsToColumnsCommand.cs
+++ b/libraries/lokql-engine/Commands/PivotRowsToColumnsCommand.cs
@@ -67,6 +67,7 @@ public static class PivotRowsToColumnsCommand
 
         var builder = TableBuilder.FromOrderedDictionarySet(o.As, ods.Values.ToList());
         exp.GetCurrentContext().AddTable(builder);
+        exp.Info($"Table '{o.As}' now available");
         return Task.CompletedTask;
     }
 
@@ -97,7 +98,7 @@ Usage:
         public string ResultName { get; set; } = string.Empty;
 
         [Option(Required=true,HelpText = "Name of table into which to project the result")]
-        public string As { get; set; } = string.Empty;
+        public string As { get; set; } = "pivoted";
 
         [Option(Required = true, HelpText = "Name column holding data values")]
         public string ValueFrom { get; set; } = string.Empty;


### PR DESCRIPTION
Make pivot commands a bit less confusing by providing a default tablename

Add project-reorder to syntax highlighting