### PR TITLE
Added base64_encode_tostring and base64_decode_tostring scalar functions

### DIFF
--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
@@ -107,6 +107,9 @@ internal static class BuiltInScalarFunctions
         ReplaceStringFunction.Register(functions);
         SubstringFunction.Register(functions);
 
+        Base64Decode.Register(functions);
+        Base64Encode.Register(functions);
+
         BinFunction.Register(functions);
         functions.Add(Functions.Floor, BinFunction.S);
         GetYearFunction.Register(functions);

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Base64Decode.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Base64Decode.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl
+{
+    [KustoImplementation(Keyword = "base64_decode_tostring")]
+    internal partial class Base64Decode
+    {
+        private static string Impl(string base64)
+        {
+            try
+            {
+                return System.Text.Encoding.UTF8.GetString(System.Convert.FromBase64String(base64));
+            }
+            catch (Exception)
+            {
+                return "";
+            }
+        }
+    }
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Base64Encode.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Base64Encode.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl
+{
+    [KustoImplementation(Keyword = "base64_encode_tostring")]
+    internal partial class Base64Encode
+    {
+        private static string Impl(string plainText)
+        {
+            try
+            {
+                return System.Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(plainText));
+            }
+            catch (Exception)
+            {
+                return "";
+            }
+        }
+    }
+}

--- a/test/CoreTests/ScalarFunctionsTests.cs
+++ b/test/CoreTests/ScalarFunctionsTests.cs
@@ -86,6 +86,34 @@ iso:string
         Test(query, expected);
     }
 
+    [Fact]
+    public void TestBase64Encode()
+    {
+        var query = """
+                    print base64=base64_encode_tostring("This string will be base64 encoded")
+                    """;
+        var expected = @"
+base64:string
+------------------
+VGhpcyBzdHJpbmcgd2lsbCBiZSBiYXNlNjQgZW5jb2RlZA==
+";
+        Test(query, expected);
+    }
+
+    [Fact]
+    public void TestBase64Decode()
+    {
+        var query = """
+                    print text=base64_decode_tostring("VGhpcyBzdHJpbmcgd2lsbCBiZSBiYXNlNjQgZW5jb2RlZA==")
+                    """;
+        var expected = @"
+text:string
+------------------
+This string will be base64 encoded
+";
+        Test(query, expected);
+    }
+
     private static void Test(string query, string expectedOutput)
     {
         var engine = BabyKustoEngine.CreateForTest();


### PR DESCRIPTION
Hi. I have been waiting for a local KQL solution for a while now so I really appreciate the effort you put into this project so far!

I have added the `base64_encode_tostring` and `base64_decode_tostring` scalar functions according to the KQL documentation.

https://learn.microsoft.com/en-us/kusto/query/base64-encode-tostring-function?view=microsoft-fabric
https://learn.microsoft.com/en-us/kusto/query/base64-decode-tostring-function?view=microsoft-fabric