### PR TITLE
Add logging to FileSystemIntellisenseService

### DIFF
--- a/Directory.Packages.Props
+++ b/Directory.Packages.Props
@@ -24,9 +24,12 @@
     <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="9.1.0-preview.1.25064.3" />
     <PackageVersion Include="Microsoft.Extensions.AI.Ollama" Version="9.1.0-preview.1.25064.3" />
     <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="9.1.0-preview.1.25064.3" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.3.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.3" />
     <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.5.0" />
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3124.44" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NLog" Version="5.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />

--- a/libraries/Intellisense/FileSystem/FileSystemIntellisenseService.cs
+++ b/libraries/Intellisense/FileSystem/FileSystemIntellisenseService.cs
@@ -1,5 +1,6 @@
 ﻿using Intellisense.FileSystem.CompletionResultRetrievers;
 using Intellisense.FileSystem.Paths;
+using Microsoft.Extensions.Logging;
 
 namespace Intellisense.FileSystem;
 
@@ -17,9 +18,11 @@ public interface IFileSystemIntellisenseService
 internal class FileSystemIntellisenseService : IFileSystemIntellisenseService
 {
     private readonly IFileSystemPathCompletionResultRetriever[] _retrievers;
+    private readonly ILogger<IFileSystemIntellisenseService> _logger;
 
-    public FileSystemIntellisenseService(IFileSystemReader reader)
+    public FileSystemIntellisenseService(IFileSystemReader reader, ILogger<IFileSystemIntellisenseService> logger)
     {
+        _logger = logger;
         _retrievers =
         [
             new ChildrenPathCompletionResultRetriever(reader),
@@ -41,9 +44,9 @@ internal class FileSystemIntellisenseService : IFileSystemIntellisenseService
                 .FirstOrDefault(x => !x.IsEmpty(),CompletionResult.Empty);
 
         }
-        catch (IOException)
+        catch (IOException e)
         {
-            // TODO: Add error logger. If a DI container ends up being introduced, extract out new() calls.
+            _logger.LogError(e,"IO error occurred while fetching intellisense results. Returning empty result.");
             return CompletionResult.Empty;
         }
     }

--- a/libraries/Intellisense/FileSystem/FileSystemIntellisenseServiceProvider.cs
+++ b/libraries/Intellisense/FileSystem/FileSystemIntellisenseServiceProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.IO.Abstractions;
+﻿using Microsoft.Extensions.Logging;
 
 namespace Intellisense.FileSystem;
 
@@ -7,12 +7,8 @@ public static class FileSystemIntellisenseServiceProvider
     private static readonly System.IO.Abstractions.FileSystem FileSystem = new();
     public static IFileSystemIntellisenseService GetFileSystemIntellisenseService()
     {
-        return GetFileSystemIntellisenseService(FileSystem);
-    }
-
-    public static IFileSystemIntellisenseService GetFileSystemIntellisenseService(IFileSystem fileSystem)
-    {
-        var fileSystemReader = new FileSystemReader(fileSystem);
-        return new FileSystemIntellisenseService(fileSystemReader);
+        var logger = new LoggerFactory().CreateLogger<FileSystemIntellisenseService>();
+        var fileSystemReader = new FileSystemReader(FileSystem);
+        return new FileSystemIntellisenseService(fileSystemReader,logger);
     }
 }

--- a/libraries/Intellisense/Intellisense.csproj
+++ b/libraries/Intellisense/Intellisense.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Logging" />
       <PackageReference Include="NotNullStrings" />
       <PackageReference Include="TestableIO.System.IO.Abstractions" />
       <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" />
@@ -18,6 +19,10 @@
       <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
         <_Parameter1>IntellisenseTests</_Parameter1>
       </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+            <!-- Allow Moq to access internal methods -->
+            <_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
+        </AssemblyAttribute>
     </ItemGroup>
 
 </Project>

--- a/test/IntellisenseTests/FileSystemIntellisenseServiceTests.cs
+++ b/test/IntellisenseTests/FileSystemIntellisenseServiceTests.cs
@@ -309,13 +309,7 @@ file class FileSystemIntellisenseServiceTestFixture
         _fileSystemIntellisenseService = new FileSystemIntellisenseService(reader,_logger);
     }
 
-    public IReadOnlyList<FakeLogRecord> GetLogs()
-    {
-        return _logger.Collector.GetSnapshot();
-    }
+    public IReadOnlyList<FakeLogRecord> GetLogs() => _logger.Collector.GetSnapshot();
 
-    public CompletionResult GetPathIntellisenseOptions(string path)
-    {
-        return _fileSystemIntellisenseService.GetPathIntellisenseOptions(path);
-    }
+    public CompletionResult GetPathIntellisenseOptions(string path) => _fileSystemIntellisenseService.GetPathIntellisenseOptions(path);
 }

--- a/test/IntellisenseTests/FileSystemIntellisenseServiceTests.cs
+++ b/test/IntellisenseTests/FileSystemIntellisenseServiceTests.cs
@@ -291,31 +291,31 @@ public class FileSystemIntellisenseServiceTests
 
 file class FileSystemIntellisenseServiceTestFixture
 {
-    private FileSystemIntellisenseService FileSystemIntellisenseService { get; }
-    private FakeLogger<IFileSystemIntellisenseService> Logger { get; }
+    private readonly FileSystemIntellisenseService _fileSystemIntellisenseService;
+    private readonly FakeLogger<IFileSystemIntellisenseService> _logger;
 
     public FileSystemIntellisenseServiceTestFixture(Dictionary<string, MockFileData> fileData, MockFileSystemOptions? options = null)
     {
         options ??= new MockFileSystemOptions { CreateDefaultTempDir = false };
         var fileSystem = new MockFileSystem(fileData, options);
         var reader = new FileSystemReader(fileSystem);
-        Logger = new FakeLogger<IFileSystemIntellisenseService>();
-        FileSystemIntellisenseService = new FileSystemIntellisenseService(reader,Logger);
+        _logger = new FakeLogger<IFileSystemIntellisenseService>();
+        _fileSystemIntellisenseService = new FileSystemIntellisenseService(reader,_logger);
     }
 
     public FileSystemIntellisenseServiceTestFixture(IFileSystemReader reader)
     {
-        Logger = new FakeLogger<IFileSystemIntellisenseService>();
-        FileSystemIntellisenseService = new FileSystemIntellisenseService(reader,Logger);
+        _logger = new FakeLogger<IFileSystemIntellisenseService>();
+        _fileSystemIntellisenseService = new FileSystemIntellisenseService(reader,_logger);
     }
 
     public IReadOnlyList<FakeLogRecord> GetLogs()
     {
-        return Logger.Collector.GetSnapshot();
+        return _logger.Collector.GetSnapshot();
     }
 
     public CompletionResult GetPathIntellisenseOptions(string path)
     {
-        return FileSystemIntellisenseService.GetPathIntellisenseOptions(path);
+        return _fileSystemIntellisenseService.GetPathIntellisenseOptions(path);
     }
 }

--- a/test/IntellisenseTests/FileSystemIntellisenseServiceTests.cs
+++ b/test/IntellisenseTests/FileSystemIntellisenseServiceTests.cs
@@ -4,9 +4,8 @@ using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
 using FluentAssertions;
 using FluentAssertions.Execution;
-using Intellisense;
 using Intellisense.FileSystem;
-using Microsoft.Extensions.Logging.Testing;
+using IntellisenseTests.Fixtures;
 using Moq;
 using Xunit;
 
@@ -286,30 +285,4 @@ public class FileSystemIntellisenseServiceTests
         var result = f.GetPathIntellisenseOptions("//unc/c/");
         result.Entries.Select(x => x.Name).Should().BeEquivalentTo("folderC1", "folderC2");
     }
-}
-
-
-file class FileSystemIntellisenseServiceTestFixture
-{
-    private readonly FileSystemIntellisenseService _fileSystemIntellisenseService;
-    private readonly FakeLogger<IFileSystemIntellisenseService> _logger;
-
-    public FileSystemIntellisenseServiceTestFixture(Dictionary<string, MockFileData> fileData, MockFileSystemOptions? options = null)
-    {
-        options ??= new MockFileSystemOptions { CreateDefaultTempDir = false };
-        var fileSystem = new MockFileSystem(fileData, options);
-        var reader = new FileSystemReader(fileSystem);
-        _logger = new FakeLogger<IFileSystemIntellisenseService>();
-        _fileSystemIntellisenseService = new FileSystemIntellisenseService(reader,_logger);
-    }
-
-    public FileSystemIntellisenseServiceTestFixture(IFileSystemReader reader)
-    {
-        _logger = new FakeLogger<IFileSystemIntellisenseService>();
-        _fileSystemIntellisenseService = new FileSystemIntellisenseService(reader,_logger);
-    }
-
-    public IReadOnlyList<FakeLogRecord> GetLogs() => _logger.Collector.GetSnapshot();
-
-    public CompletionResult GetPathIntellisenseOptions(string path) => _fileSystemIntellisenseService.GetPathIntellisenseOptions(path);
 }

--- a/test/IntellisenseTests/Fixtures/FileSystemIntellisenseServiceTestFixture.cs
+++ b/test/IntellisenseTests/Fixtures/FileSystemIntellisenseServiceTestFixture.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System.IO.Abstractions.TestingHelpers;
+using Intellisense;
+using Intellisense.FileSystem;
+using Microsoft.Extensions.Logging.Testing;
+
+namespace IntellisenseTests.Fixtures;
+
+internal class FileSystemIntellisenseServiceTestFixture
+{
+    private readonly FileSystemIntellisenseService _fileSystemIntellisenseService;
+    private readonly FakeLogger<IFileSystemIntellisenseService> _logger;
+
+    public FileSystemIntellisenseServiceTestFixture(Dictionary<string, MockFileData> fileData, MockFileSystemOptions? options = null)
+    {
+        options ??= new MockFileSystemOptions { CreateDefaultTempDir = false };
+        var fileSystem = new MockFileSystem(fileData, options);
+        var reader = new FileSystemReader(fileSystem);
+        _logger = new FakeLogger<IFileSystemIntellisenseService>();
+        _fileSystemIntellisenseService = new FileSystemIntellisenseService(reader,_logger);
+    }
+
+    public FileSystemIntellisenseServiceTestFixture(IFileSystemReader reader)
+    {
+        _logger = new FakeLogger<IFileSystemIntellisenseService>();
+        _fileSystemIntellisenseService = new FileSystemIntellisenseService(reader,_logger);
+    }
+
+    public IReadOnlyList<FakeLogRecord> GetLogs() => _logger.Collector.GetSnapshot();
+
+    public CompletionResult GetPathIntellisenseOptions(string path) => _fileSystemIntellisenseService.GetPathIntellisenseOptions(path);
+}

--- a/test/IntellisenseTests/IntellisenseTests.csproj
+++ b/test/IntellisenseTests/IntellisenseTests.csproj
@@ -11,7 +11,9 @@
 
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">


### PR DESCRIPTION
I'm adding test coverage as I go through my bucket list in #171. I think error handling is something fairly important to get test coverage for, so it's worth the extra amount of code this took.

# Changes
- Added packages for logging and mocking
- Added error logging in `FileSystemIntellisenseService`
- Refactorings to `FileSystemIntellisenseServiceTestFixture` construction & extract into own file