### PR TITLE
Add intellisense support for all other file IO commands

### DIFF
--- a/applications/lokqlDx/MainWindow.xaml.cs
+++ b/applications/lokqlDx/MainWindow.xaml.cs
@@ -9,7 +9,6 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shell;
-using Intellisense;
 using Lokql.Engine;
 using Microsoft.Win32;
 using NotNullStrings;

--- a/applications/lokqlDx/MainWindow.xaml.cs
+++ b/applications/lokqlDx/MainWindow.xaml.cs
@@ -163,7 +163,9 @@ public partial class MainWindow : Window
         Editor.AddInternalCommands(_explorer._commandProcessor.GetVerbs()
             .Select(v =>
                 new IntellisenseEntry(v.Key, v.Value, string.Empty))
-            .ToArray());
+            .ToArray(),
+            _explorer._commandProcessor.GetVerbsOfOptionsThatTakeFilesAsInput().Select(x => "." + x)
+            );
         RegistryOperations.AssociateFileType(true);
         PreferencesManager.EnsureDefaultFolderExists();
         UpdateDynamicUiFromPreferences();

--- a/applications/lokqlDx/MainWindow.xaml.cs
+++ b/applications/lokqlDx/MainWindow.xaml.cs
@@ -160,12 +160,7 @@ public partial class MainWindow : Window
     private async void MainWindow_OnLoaded(object sender, RoutedEventArgs e)
     {
         _preferenceManager.RetrieveUiPreferencesFromDisk();
-        Editor.AddInternalCommands(_explorer._commandProcessor.GetVerbs()
-            .Select(v =>
-                new IntellisenseEntry(v.Key, v.Value, string.Empty))
-            .ToArray(),
-            _explorer._commandProcessor.GetVerbsOfOptionsThatTakeFilesAsInput().Select(x => "." + x)
-            );
+        Editor.AddInternalCommands(_explorer._commandProcessor.GetVerbs());
         RegistryOperations.AssociateFileType(true);
         PreferencesManager.EnsureDefaultFolderExists();
         UpdateDynamicUiFromPreferences();

--- a/applications/lokqlDx/QueryEditor.xaml.cs
+++ b/applications/lokqlDx/QueryEditor.xaml.cs
@@ -368,10 +368,13 @@ public partial class QueryEditor : UserControl
         if (e.Text == "?") ShowCompletions(_kqlFunctionEntries, string.Empty, 1);
     }
 
-    public void AddInternalCommands(IntellisenseEntry[] verbs, IEnumerable<string> fileIoVerbs)
+    public void AddInternalCommands(IEnumerable<VerbEntry> verbEntries)
     {
-        _internalCommands = verbs;
-        _fileIoCommandParser = new FileIoCommandParser(fileIoVerbs);
+        var verbs = verbEntries.ToArray();
+        _internalCommands = verbs.Select(v =>
+                new IntellisenseEntry(v.Name, v.HelpText, string.Empty))
+            .ToArray();
+        _fileIoCommandParser = new FileIoCommandParser(verbs.Select(x => "." + x.Name));
     }
 
     private void textEditor_TextArea_TextEntering(object sender, TextCompositionEventArgs e)

--- a/applications/lokqlDx/QueryEditor.xaml.cs
+++ b/applications/lokqlDx/QueryEditor.xaml.cs
@@ -38,7 +38,7 @@ public partial class QueryEditor : UserControl
     private CommandParser? _parser;
     private CommandParser Parser
     {
-        get => _parser ?? throw new UnreachableException($"Did not expect {nameof(Parser)} to be uninitialized.");
+        get => _parser ?? throw new InvalidOperationException($"Did not expect {nameof(Parser)} to be uninitialized. Was this accessed before initialization in {nameof(AddInternalCommands)}?");
         set => _parser = value;
     }
 

--- a/libraries/Intellisense/CommandParser.cs
+++ b/libraries/Intellisense/CommandParser.cs
@@ -1,0 +1,32 @@
+﻿using System.CommandLine.Parsing;
+
+namespace Intellisense;
+
+public class CommandParser
+{
+    private readonly HashSet<string> _supportedCommands;
+
+    public CommandParser(IEnumerable<string> supportedCommands, string prefix)
+    {
+        _supportedCommands = supportedCommands
+            .Select(x => prefix + x)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    public string GetLastArgument(string text)
+    {
+        var args = CommandLineStringSplitter.Instance.Split(text).ToArray();
+
+        if (args.Length < 2)
+        {
+            return string.Empty;
+        }
+
+        if (!_supportedCommands.Contains(args[0]))
+        {
+            return string.Empty;
+        }
+
+        return args[^1];
+    }
+}

--- a/libraries/Intellisense/Intellisense.csproj
+++ b/libraries/Intellisense/Intellisense.csproj
@@ -9,6 +9,7 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Logging" />
       <PackageReference Include="NotNullStrings" />
+      <PackageReference Include="System.CommandLine" />
       <PackageReference Include="TestableIO.System.IO.Abstractions" />
       <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" />
       <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" />

--- a/libraries/lokql-engine/Commands/CommandProcessor.cs
+++ b/libraries/lokql-engine/Commands/CommandProcessor.cs
@@ -118,10 +118,9 @@ public class CommandProcessor
 
     public IEnumerable<VerbEntry> GetVerbs()
     {
-
         var verbs = from type in _registrations.Select(x => x.OptionType)
             let attribute = type.GetTypeInfo().GetCustomAttribute<VerbAttribute>()
-            where attribute is not null
+                            ?? throw new InvalidOperationException($"All registered command options should have a {nameof(VerbAttribute)}. {type.FullName ?? type.Name} does not.")
             let supportsFiles = type.IsAssignableTo(typeof(IFileCommandOption))
             select new VerbEntry(attribute.Name, attribute.HelpText, supportsFiles);
 

--- a/libraries/lokql-engine/Commands/CommandProcessor.cs
+++ b/libraries/lokql-engine/Commands/CommandProcessor.cs
@@ -118,6 +118,7 @@ public class CommandProcessor
 
     public Dictionary<string, string> GetVerbs()
     {
+
         var verbs= _registrations
             .SelectMany(t => t.OptionType.GetTypeInfo().GetCustomAttributes(typeof(VerbAttribute), true))
             .OfType<VerbAttribute>()
@@ -126,6 +127,16 @@ public class CommandProcessor
 .help            for a summary of all commands
 .help *command*  for details of a specific command";
         return verbs;
+    }
+
+    public IEnumerable<string> GetVerbsOfOptionsThatTakeFilesAsInput()
+    {
+        var verbs = _registrations
+            .Where(x => x.OptionType.IsAssignableTo(typeof(IFileCommandOption)))
+            .SelectMany(t => t.OptionType.GetTypeInfo().GetCustomAttributes(typeof(VerbAttribute), true))
+            .OfType<VerbAttribute>();
+
+        return verbs.Select(x => x.Name);
     }
 
     private readonly record struct RegisteredCommand(

--- a/libraries/lokql-engine/Commands/CommandProcessor.cs
+++ b/libraries/lokql-engine/Commands/CommandProcessor.cs
@@ -128,6 +128,7 @@ public class CommandProcessor
 
         static VerbEntry CreateHelpEntry()
         {
+            // Help is a default command in CommandLineParser but we still need to provide metadata for it.
             const string helpText = @"Shows a list of available commands or help for a specific command
 .help            for a summary of all commands
 .help *command*  for details of a specific command";

--- a/libraries/lokql-engine/Commands/FinishReportCommand.cs
+++ b/libraries/lokql-engine/Commands/FinishReportCommand.cs
@@ -17,7 +17,7 @@ public static class FinishReportCommand
     }
 
     [Verb("finishreport", HelpText = @"finish a report by saving it out as a file")]
-    internal class Options
+    internal class Options : IFileCommandOption
     {
         [Value(0, HelpText = "Name of file to save report to ", Required = true)]
         public string File { get; set; } = string.Empty;

--- a/libraries/lokql-engine/Commands/LoadCommand.cs
+++ b/libraries/lokql-engine/Commands/LoadCommand.cs
@@ -42,7 +42,7 @@ When loading text files, a single column named 'Line' is created.
 Examples:
  .load c:\temp\data.csv        
  .load d.parquet data2 ")]
-    internal class Options
+    internal class Options : IFileCommandOption
     {
         [Value(0, HelpText = "Name of file", Required = true)]
         public string File { get; set; } = string.Empty;

--- a/libraries/lokql-engine/Commands/LoadExcel.cs
+++ b/libraries/lokql-engine/Commands/LoadExcel.cs
@@ -48,7 +48,7 @@ public static class LoadExcel
         HelpText = @"loads multiple tables from an excel spreadsheet.
 Tables are named after the worksheet that contains them, with an optional prefix.
 ")]
-    internal class Options
+    internal class Options : IFileCommandOption
     {
         [Value(0, HelpText = "Name of file", Required = true)]
         public string File { get; set; } = string.Empty;

--- a/libraries/lokql-engine/Commands/QueryCommand.cs
+++ b/libraries/lokql-engine/Commands/QueryCommand.cs
@@ -16,7 +16,7 @@ public static class QueryCommand
 
     [Verb("query", aliases: ["q"],
         HelpText = "run a multi-line query from a file")]
-    internal class Options
+    internal class Options : IFileCommandOption
     {
         [Value(0, HelpText = "Name of queryFile", Required = true)]
         public string File { get; set; } = string.Empty;

--- a/libraries/lokql-engine/Commands/RunScriptCommand.cs
+++ b/libraries/lokql-engine/Commands/RunScriptCommand.cs
@@ -18,7 +18,7 @@ public static class RunScriptCommand
 
     [Verb("run", aliases: ["script", "r"],
         HelpText = "run a script")]
-    internal class Options
+    internal class Options : IFileCommandOption
     {
         [Value(0, HelpText = "Name of script", Required = true)]
         public string File { get; set; } = string.Empty;

--- a/libraries/lokql-engine/Commands/SaveCommand.cs
+++ b/libraries/lokql-engine/Commands/SaveCommand.cs
@@ -21,7 +21,7 @@ Examples:
   .save c:\temp\data.csv #saves the most recent result to a csv file
   .save d.parquet abc    #saves a named result called 'abc' to a parquet file
 ")]
-    internal class Options
+    internal class Options : IFileCommandOption
     {
         [Value(0, HelpText = "Name of file", Required = true)]
         public string File { get; set; } = string.Empty;

--- a/libraries/lokql-engine/Commands/SaveQueryCommand.cs
+++ b/libraries/lokql-engine/Commands/SaveQueryCommand.cs
@@ -28,7 +28,7 @@ public static class SaveQueryCommand
 
     [Verb("savequery", aliases: ["sq"],
         HelpText = "save the previous query to a file so you can reuse it")]
-    internal class Options
+    internal class Options : IFileCommandOption
     {
         [Value(0, HelpText = "Name of queryFile", Required = true)]
         public string File { get; set; } = string.Empty;

--- a/libraries/lokql-engine/IFileCommandOption.cs
+++ b/libraries/lokql-engine/IFileCommandOption.cs
@@ -1,0 +1,9 @@
+﻿namespace Lokql.Engine;
+
+/// <summary>
+/// Command option that takes a file path as input.
+/// </summary>
+public interface IFileCommandOption
+{
+    string File { get; }
+}

--- a/libraries/lokql-engine/VerbEntry.cs
+++ b/libraries/lokql-engine/VerbEntry.cs
@@ -1,0 +1,3 @@
+﻿namespace Lokql.Engine;
+
+public readonly record struct VerbEntry(string Name, string HelpText, bool SupportsFiles);

--- a/test/IntellisenseTests/CommandParserTests.cs
+++ b/test/IntellisenseTests/CommandParserTests.cs
@@ -1,0 +1,52 @@
+﻿using FluentAssertions;
+using Intellisense;
+using Xunit;
+
+namespace IntellisenseTests;
+
+public class CommandParserTests
+{
+    [Fact]
+    public void GetLastArgument_IgnoresCase()
+    {
+        var commands = new[] { "LOAD" };
+        var parser = new CommandParser(commands, ".");
+
+        var result = parser.GetLastArgument(".load /abcdefgh");
+
+        result.Should().Be("/abcdefgh");
+    }
+
+    [Fact]
+    public void GetLastArgument_HandlesQuotes()
+    {
+        var commands = new[] { "save" };
+        var parser = new CommandParser(commands, ".");
+
+        var result = parser.GetLastArgument(".save \"/abcdefgh\"");
+
+        result.Should().Be("/abcdefgh");
+    }
+
+    [Fact]
+    public void GetLastArgument_TextDoesntStartWithCommand_ReturnsEmpty()
+    {
+        var commands = new[] { "save" };
+        var parser = new CommandParser(commands, ".");
+
+        var result = parser.GetLastArgument("abc .save /abcde");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetLastArgument_IgnoresSurroundingWhitespaceAndExcessWhitespace()
+    {
+        var commands = new[] { "save" };
+        var parser = new CommandParser(commands, ".");
+
+        var result = parser.GetLastArgument(" \r\n \t \n  .save \r\n \n \r\n \n  \t  /abcde   \r\n \n \t ");
+
+        result.Should().Be("/abcde");
+    }
+}

--- a/test/LokqlEngineTests/CommandProcessorTests.cs
+++ b/test/LokqlEngineTests/CommandProcessorTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using FluentAssertions.Execution;
 using Lokql.Engine.Commands;
 
 namespace LokqlEngineTests;
@@ -7,15 +8,24 @@ namespace LokqlEngineTests;
 public class CommandProcessorTests
 {
     [TestMethod]
-    public void GetVerbs_SupportsFiles_OnlyContainsVerbsWithFileParameter()
+    public void GetVerbsIdentifiesVerbsOfOptionsAcceptingFiles()
     {
         var processor = CommandProcessor.Default();
 
-        var result = processor.GetVerbs().Where(x => x.SupportsFiles);
+        var result = processor.GetVerbs().ToArray();
+
+        using var _ = new AssertionScope();
 
         result
             .Should()
             .ContainSingle(x => x.Name.Equals("load", StringComparison.OrdinalIgnoreCase))
-            .And.NotContain(x => x.Name.Equals("synonym", StringComparison.OrdinalIgnoreCase)); // SynTableCommand
+            .Which.SupportsFiles.Should()
+            .BeTrue();
+
+        result
+            .Should()
+            .ContainSingle(x => x.Name.Equals("synonym", StringComparison.OrdinalIgnoreCase))
+            .Which.SupportsFiles.Should()
+            .BeFalse();
     }
 }

--- a/test/LokqlEngineTests/CommandProcessorTests.cs
+++ b/test/LokqlEngineTests/CommandProcessorTests.cs
@@ -7,15 +7,15 @@ namespace LokqlEngineTests;
 public class CommandProcessorTests
 {
     [TestMethod]
-    public void GetVerbsOfOptionsThatTakeFilesAsInputDoesWhatItsNameDescribes()
+    public void GetVerbs_SupportsFiles_OnlyContainsVerbsWithFileParameter()
     {
         var processor = CommandProcessor.Default();
 
-        var result = processor.GetVerbsOfOptionsThatTakeFilesAsInput();
+        var result = processor.GetVerbs().Where(x => x.SupportsFiles);
 
         result
             .Should()
-            .ContainSingle(x => x.Equals("load", StringComparison.OrdinalIgnoreCase))
-            .And.NotContain(x => x.Equals("synonym", StringComparison.OrdinalIgnoreCase)); // SynTableCommand
+            .ContainSingle(x => x.Name.Equals("load", StringComparison.OrdinalIgnoreCase))
+            .And.NotContain(x => x.Name.Equals("synonym", StringComparison.OrdinalIgnoreCase)); // SynTableCommand
     }
 }

--- a/test/LokqlEngineTests/CommandProcessorTests.cs
+++ b/test/LokqlEngineTests/CommandProcessorTests.cs
@@ -1,0 +1,21 @@
+﻿using FluentAssertions;
+using Lokql.Engine.Commands;
+
+namespace LokqlEngineTests;
+
+[TestClass]
+public class CommandProcessorTests
+{
+    [TestMethod]
+    public void GetVerbsOfOptionsThatTakeFilesAsInputDoesWhatItsNameDescribes()
+    {
+        var processor = CommandProcessor.Default();
+
+        var result = processor.GetVerbsOfOptionsThatTakeFilesAsInput();
+
+        result
+            .Should()
+            .ContainSingle(x => x.Equals("load", StringComparison.OrdinalIgnoreCase))
+            .And.NotContain(x => x.Equals("synonym", StringComparison.OrdinalIgnoreCase)); // SynTableCommand
+    }
+}


### PR DESCRIPTION
Related to #171

# Context
Currently, only `.save` and `.load` support path intellisense. This PR identifies commands that take files as input by marking all command options containing a `File` parameter with an interface `IFileCommandOption`, which are then retrieved and transformed into `VerbEntry` objects via reflection. These `VerbEntry` objects are intended to provide all necessary data for intellisense functionality from command metadata and can be expanded upon in #176. For this PR, they are used to initialize parsing logic in triggering autocompletion and to populate command completion options.

# Other changes
- Extracted and renamed `FileIOCommandParser` => `CommandParser` for test coverage, minor refactorings
- Simplify command option verb attribute retrieval, fail eagerly when option is registered and doesn't have a verb attribute
