### PR TITLE
Autogenerate help docs and sync to wiki

### DIFF
--- a/.github/workflows/update-wiki.yml
+++ b/.github/workflows/update-wiki.yml
@@ -1,0 +1,64 @@
+﻿name: Update Wiki
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+permissions: # needed to write to wiki repository with just the workflow's access token rather than PAT
+  contents: write
+  pages: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Main Repository
+        uses: actions/checkout@v4
+        with:
+          path: repo
+      - name: Checkout Wiki
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}.wiki
+          path: wiki
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+      - name: Update Wiki
+        shell: pwsh
+        run: |
+          # generate docs
+          
+          pushd repo
+          
+          $fileName = "LokqlDx-‐-commands.md"
+          $location = "../wiki/$fileName"
+        
+          
+          Write-Host "Generating docs"
+          dotnet run --project ./applications/lokql -- -c ".help" | select -skip 3 | set-content $location
+          
+          # merge and push changes
+          
+          popd
+          cd wiki
+          
+          # https://github.com/actions/checkout?tab=readme-ov-file#push-a-commit-using-the-built-in-token
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          
+          Write-Host "Adding changes"
+          git add --all
+          $hasChanges = (git diff --staged --shortstat | measure-object).Count -gt 0
+          if (!$hasChanges){
+            Write-Host "No changes detected. No changes made to wiki."
+            return;
+          }
+          
+          Write-Host "Committing changes"
+          git commit -m "chore: auto update command help ${{ github.run_id }}"
+          Write-Host "Pushing changes"
+          git push
+          Write-Host "Successfully updated wiki with changes."

--- a/applications/lokql/CmdRun.cs
+++ b/applications/lokql/CmdRun.cs
@@ -4,6 +4,7 @@ using KustoLoco.Core.Settings;
 using Lokql.Engine;
 using Lokql.Engine.Commands;
 using NLog;
+using NotNullStrings;
 
 /// <summary>
 ///     Interactive data explorer
@@ -22,7 +23,7 @@ internal class CmdRun
         var processor = CommandProcessorProvider.GetCommandProcessor();
         var renderer = new NullResultRenderingSurface();
         var explorer = new InteractiveTableExplorer(console, loader, settings, processor,renderer);
-        var block = File.ReadAllText(options.Run);
+        var block = options.File.IsBlank() ? options.Command : File.ReadAllText(options.File);
         await explorer.RunInput(block);
     }
 
@@ -40,14 +41,16 @@ internal class CmdRun
         }
     }
 
-    [Verb("run", HelpText = "runs a lokqldx workspace in its entirety")]
+    [Verb("run", isDefault:true,  HelpText = "runs a lokqldx workspace in its entirety")]
     public class Options
     {
         [Option(HelpText = "Default folder to load/save data/results to")]
         public string Data { get; set; } = string.Empty;
 
+        [Option(shortName: 'f', HelpText = "Runs a script at startup", Required = true, SetName = nameof(File))]
+        public string File { get; set; } = string.Empty;
 
-        [Option(HelpText = "Runs a script at startup")]
-        public string Run { get; set; } = string.Empty;
+        [Option(shortName:'c', HelpText = "Runs a script provided as a string",   Required = true, SetName = nameof(Command))]
+        public string Command { get; set; } = string.Empty;
     }
 }


### PR DESCRIPTION
Fixes #182 

This is the last of a series of changes discussed in the original issue. Prettifying the format is probably going to be later as part of a larger PR.

# Changes
- Small improvements to command parsing UX for the console app `lokql`
- Added workflow on push to main to diff and merge new changes from command help content into the wiki for `LokqlDx-‐-commands.md`