### PR TITLE
Simplify datagrid binding in AV port

### DIFF
--- a/applications/lokqlDx-Av/ViewModels/RenderingSurfaceViewModel.cs
+++ b/applications/lokqlDx-Av/ViewModels/RenderingSurfaceViewModel.cs
@@ -5,6 +5,7 @@ using KustoLoco.Core.Settings;
 using KustoLoco.Rendering.ScottPlot;
 using Lokql.Engine.Commands;
 using lokqlDx;
+using NotNullStrings;
 using ScottPlot;
 
 namespace LokqlDx.ViewModels;
@@ -47,10 +48,12 @@ public partial class RenderingSurfaceViewModel : ObservableObject, IResultRender
 
     private Task RenderTable(KustoQueryResult result)
     {
+        
         //ensure that if there are no results we clear the data grid
-        if (result.RowCount == 0)
+        if (result.Error.IsNotBlank())
         {
-            Results = null;
+            Results = new ObservableCollection<Row>([new Row([result.Error])]);
+            Columns = new List<string>(["ERROR"]);
             return Task.CompletedTask;
         }
 

--- a/applications/lokqlDx-Av/ViewModels/RenderingSurfaceViewModel.cs
+++ b/applications/lokqlDx-Av/ViewModels/RenderingSurfaceViewModel.cs
@@ -15,12 +15,12 @@ public partial class RenderingSurfaceViewModel : ObservableObject, IResultRender
     private readonly KustoSettingsProvider _kustoSettings;
     [ObservableProperty] private List<string> _columns = [];
 
-    [ObservableProperty] private string? _dataGridSizeWarning;
+    [ObservableProperty] private string _dataGridSizeWarning=string.Empty;
     [ObservableProperty] private double _fontSize = 20;
 
 
     private IScottPlotHost _plotter = new NullScottPlotHost();
-    [ObservableProperty] private ObservableCollection<Row>? _results;
+    [ObservableProperty] private ObservableCollection<Row> _results = [];
     [ObservableProperty] private bool _showDataGridSizeWarning;
 
     public RenderingSurfaceViewModel(KustoSettingsProvider kustoSettings)

--- a/applications/lokqlDx-Av/Views/RenderingSurfaceView.axaml.cs
+++ b/applications/lokqlDx-Av/Views/RenderingSurfaceView.axaml.cs
@@ -51,7 +51,8 @@ public partial class RenderingSurfaceView : UserControl, IDisposable, IScottPlot
                     DataGrid.Columns.Add(new DataGridTextColumn
                     {
                         Header = column,
-                        Binding = new Binding(RenderingSurfaceViewModel.Row.GetPath(i))
+                        Binding = new Binding(RenderingSurfaceViewModel.Row.GetPath(i),BindingMode.OneWay)
+                       
                     });
                 }
             });

--- a/libraries/lokql-engine/InteractiveTableExplorer.cs
+++ b/libraries/lokql-engine/InteractiveTableExplorer.cs
@@ -143,8 +143,7 @@ public class InteractiveTableExplorer
             }
 
             var result = await GetCurrentContext().RunQuery(query);
-            if (result.Error.Length == 0) await _renderingSurface.RenderToDisplay(result);
-
+            await _renderingSurface.RenderToDisplay(result);
             _resultHistory.Push(result);
 
             DisplayResults(result);


### PR DESCRIPTION
@Epacik fyi - I've simplified the datagrid binding.  Since the Row is never updated "live" we can just copy the data out of the KustoQueryResult.