### PR TITLE
Fixing hotkeys, fallback for monospace fontfamily, and more reasonable background for non-mica transparency levels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ _NCrunch_BabyKusto
 /.NCrunch_KustoLoco/StoredText
 /publish
 /uploads
+
+#IntelliJ (Rider) temp files
+.idea

--- a/applications/lokqlDx-Av/Preferences/PreferencesHelper.cs
+++ b/applications/lokqlDx-Av/Preferences/PreferencesHelper.cs
@@ -5,7 +5,7 @@ namespace LokqlDx;
 
 public static class PreferencesHelper
 {
-    public static FontFamily? GetDefaultMonospaceFontFamily()
+    public static FontFamily? GetFirstMonospaceFontFamily()
     {
         var fonts = FontManager.Current.SystemFonts
             .OrderBy(x => x.Name)

--- a/applications/lokqlDx-Av/Preferences/PreferencesHelper.cs
+++ b/applications/lokqlDx-Av/Preferences/PreferencesHelper.cs
@@ -1,0 +1,37 @@
+using System.Globalization;
+using Avalonia.Media;
+
+namespace LokqlDx;
+
+public static class PreferencesHelper
+{
+    public static FontFamily? GetDefaultMonospaceFontFamily()
+    {
+        var fonts = FontManager.Current.SystemFonts
+            .OrderBy(x => x.Name)
+            .ToList();
+        
+        return fonts.FirstOrDefault(IsMonospaced);
+    }
+
+    private static readonly char[] _testChars = ['W', 'I', '1', '*'];
+    public static bool IsMonospaced(FontFamily fontFamily)
+    {
+        var typeface = new Typeface(fontFamily, FontStyle.Normal, FontWeight.Normal, FontStretch.Normal);
+        var n = 50;
+
+        var texts = _testChars
+            .Select(x => new FormattedText(
+                string.Empty.PadRight(n, x),
+                CultureInfo.InvariantCulture,
+                FlowDirection.LeftToRight,
+                typeface,
+                20,
+                Brushes.Black))
+            .Select(x => x.WidthIncludingTrailingWhitespace)
+            .ToList();
+        
+        var first = texts.First();
+        return texts.All(x => x == first);
+    }
+}

--- a/applications/lokqlDx-Av/Preferences/PreferencesManager.cs
+++ b/applications/lokqlDx-Av/Preferences/PreferencesManager.cs
@@ -1,6 +1,5 @@
 ﻿using System.Text.Json;
 using Avalonia.Media;
-using SkiaSharp;
 
 namespace LokqlDx;
 

--- a/applications/lokqlDx-Av/Preferences/PreferencesManager.cs
+++ b/applications/lokqlDx-Av/Preferences/PreferencesManager.cs
@@ -5,7 +5,7 @@ namespace LokqlDx;
 public class PreferencesManager
 {
     private const string UIPreferencesFileName = "ui";
-    private const string ApplicationPreferencesFileName = "preferences";
+    private const string ApplicationPreferencesFileName = "preferences2";
     private const string MruFileName = "mru";
     private readonly JsonSerializerOptions _options = new() { WriteIndented = true };
     private ApplicationPreferences _cachedApplicationPreferences = new();

--- a/applications/lokqlDx-Av/Preferences/PreferencesManager.cs
+++ b/applications/lokqlDx-Av/Preferences/PreferencesManager.cs
@@ -86,7 +86,7 @@ public class PreferencesManager
             f.Name == "SF Mono" || f.Name == "Menlo" || f.Name == "Monaco" || // macOS defaults
             f.Name == "Noto Sans Mono" || f.Name == "DejaVu Sans Mono" || // some linux distros defaults
             f.Name.Contains("Mono", StringComparison.OrdinalIgnoreCase)) 
-            ?? PreferencesHelper.GetDefaultMonospaceFontFamily()
+            ?? PreferencesHelper.GetFirstMonospaceFontFamily()
             ?? FontManager.Current.DefaultFontFamily;
 
         UIPreferences.FontFamily = font.Name;

--- a/applications/lokqlDx-Av/Services/DialogService.cs
+++ b/applications/lokqlDx-Av/Services/DialogService.cs
@@ -1,5 +1,7 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Markup.Xaml.MarkupExtensions;
 using Avalonia.Media;
 using LokqlDx.Models;
 using LokqlDx.ViewModels.Dialogs;
@@ -83,9 +85,11 @@ public class DialogService
                 DataContext = dataContext,
                 TransparencyLevelHint =
                     [WindowTransparencyLevel.Mica, WindowTransparencyLevel.AcrylicBlur, WindowTransparencyLevel.Blur],
-                Background = window.FindResource("SystemListLowColor") as IBrush,
                 WindowStartupLocation = WindowStartupLocation.CenterOwner
             };
+
+            dialog[!TemplatedControl.BackgroundProperty] =
+                new DynamicResourceExtension("SystemControlBackgroundAltMediumHighBrush");
 
 #if DEBUG
             dialog.AttachDevTools();

--- a/applications/lokqlDx-Av/Services/DialogService.cs
+++ b/applications/lokqlDx-Av/Services/DialogService.cs
@@ -88,11 +88,18 @@ public class DialogService
                 WindowStartupLocation = WindowStartupLocation.CenterOwner
             };
 
-            dialog[!TemplatedControl.BackgroundProperty] =
-                new DynamicResourceExtension("SystemControlBackgroundAltMediumHighBrush");
+            if (window.ActualTransparencyLevel != WindowTransparencyLevel.Mica)
+            {
+                dialog[!TemplatedControl.BackgroundProperty]
+                    = new DynamicResourceExtension("SystemControlBackgroundAltMediumHighBrush");
+            }
+            else
+            {
+                dialog.Background = Brushes.Transparent;
+            }
 
 #if DEBUG
-            dialog.AttachDevTools();
+                dialog.AttachDevTools();
 #endif
 
 #pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks

--- a/applications/lokqlDx-Av/ViewModels/MainViewModel.cs
+++ b/applications/lokqlDx-Av/ViewModels/MainViewModel.cs
@@ -25,21 +25,22 @@ public partial class MainViewModel : ObservableObject
     private readonly RegistryOperations _registryOperations;
     private readonly IStorageProvider _storage;
     private readonly WorkspaceManager _workspaceManager;
-    [ObservableProperty] private ColumnDefinitions? _columnDefinitions;
     private CommandProcessor _commandProcessor;
+    private InteractiveTableExplorer _explorer;
+    private string? _initWorkspacePath;
+
+    [ObservableProperty] private ColumnDefinitions? _columnDefinitions;
     [ObservableProperty] private ConsoleViewModel _consoleViewModel;
     [ObservableProperty] private CopilotChatViewModel _copilotChatViewModel;
 
     [ObservableProperty] private Workspace? _currentWorkspace;
 
-    private InteractiveTableExplorer _explorer;
-
-    private string? _initWorkspacePath;
     [ObservableProperty] private QueryEditorViewModel _queryEditorViewModel;
     [ObservableProperty] private ObservableCollection<RecentWorkspace> _recentWorkspaces = [];
     [ObservableProperty] private RenderingSurfaceViewModel _renderingSurfaceViewModel;
     [ObservableProperty] private RowDefinitions? _rowDefinitions;
     [ObservableProperty] private string? _updateInfo;
+    [ObservableProperty] private bool _showUpdateInfo;
     [ObservableProperty] private Point _windowPosition;
     [ObservableProperty] private Size _windowSize;
     [ObservableProperty] private string _windowTitle = "LokqlDX";
@@ -99,11 +100,11 @@ public partial class MainViewModel : ObservableObject
         await LoadWorkspace(_initWorkspacePath ?? "");
 
         var isNewVersionAvailable = await UpgradeManager.UpdateAvailable();
-        //if (isNewVersionAvailable)
-        //{
-        //    StatusBar.Visibility = Visibility.Visible;
-        //    UpdateInfo.Content = "New version available";
-        //}
+        if (isNewVersionAvailable)
+        {
+            ShowUpdateInfo = true;
+            UpdateInfo = "New version available";
+        }
     }
 
     [RelayCommand]
@@ -186,6 +187,7 @@ public partial class MainViewModel : ObservableObject
             _preferencesManager.UIPreferences.FontSize + by,
             6, 40);
         ApplyUiPreferences(true);
+        _preferencesManager.SaveUiPrefs();
     }
 
     [RelayCommand]
@@ -193,6 +195,7 @@ public partial class MainViewModel : ObservableObject
     {
         _preferencesManager.UIPreferences.WordWrap = !_preferencesManager.UIPreferences.WordWrap;
         ApplyUiPreferences(true);
+        _preferencesManager.SaveUiPrefs();
     }
 
     [RelayCommand]
@@ -200,6 +203,7 @@ public partial class MainViewModel : ObservableObject
     {
         _preferencesManager.UIPreferences.ShowLineNumbers = !_preferencesManager.UIPreferences.ShowLineNumbers;
         ApplyUiPreferences(true);
+        _preferencesManager.SaveUiPrefs();
     }
 
     [RelayCommand]

--- a/applications/lokqlDx-Av/Views/DispatcherHelper.cs
+++ b/applications/lokqlDx-Av/Views/DispatcherHelper.cs
@@ -7,7 +7,7 @@ namespace LokqlDx.Views;
 /// </summary>
 public static class DispatcherHelper
 {
-    public static async Task<T> SafeInvoke<T>(Func<Task<T>> func) => await Dispatcher.UIThread.Invoke(func);
+    public static async Task<T> SafeInvoke<T>(Func<Task<T>> func) => await Dispatcher.UIThread.InvokeAsync(func);
     public static T SafeInvoke<T>(Func<T> func) =>  Dispatcher.UIThread.Invoke(func);
     public static void SafeInvoke(Action func) => Dispatcher.UIThread.Invoke(func);
 

--- a/applications/lokqlDx-Av/Views/MainView.axaml
+++ b/applications/lokqlDx-Av/Views/MainView.axaml
@@ -5,6 +5,7 @@
              xmlns:vm="using:LokqlDx.ViewModels"
              xmlns:views="using:LokqlDx.Views"
              xmlns:system="using:System"
+             Background="{DynamicResource SystemAltMediumHighColor}"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="LokqlDx.Views.MainView"
              x:DataType="vm:MainViewModel">

--- a/applications/lokqlDx-Av/Views/MainView.axaml
+++ b/applications/lokqlDx-Av/Views/MainView.axaml
@@ -5,7 +5,6 @@
              xmlns:vm="using:LokqlDx.ViewModels"
              xmlns:views="using:LokqlDx.Views"
              xmlns:system="using:System"
-             Background="{DynamicResource SystemAltMediumHighColor}"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="LokqlDx.Views.MainView"
              x:DataType="vm:MainViewModel">

--- a/applications/lokqlDx-Av/Views/MainView.axaml
+++ b/applications/lokqlDx-Av/Views/MainView.axaml
@@ -20,12 +20,28 @@
         </EventTriggerBehavior>
     </Interaction.Behaviors>
 
+    <UserControl.KeyBindings>
+        <KeyBinding Gesture="Ctrl+S" Command="{Binding SaveWorkspaceCommand}"/>
+        <KeyBinding Gesture="Ctrl+Shift+S" Command="{Binding SaveWorkspaceAsCommand}"/>
+        <KeyBinding Gesture="Ctrl+D9" Command="{Binding ChangeFontSizeCommand}">
+            <KeyBinding.CommandParameter>
+                <system:Int32>-1</system:Int32>
+            </KeyBinding.CommandParameter>
+        </KeyBinding>
+        <KeyBinding Gesture="Ctrl+D0" Command="{Binding ChangeFontSizeCommand}">
+            <KeyBinding.CommandParameter>
+                <system:Int32>1</system:Int32>
+            </KeyBinding.CommandParameter>
+        </KeyBinding>
+        <KeyBinding Gesture="Alt+Z" Command="{Binding ToggleWordWrapCommand}"/>
+        <KeyBinding Gesture="Alt+N" Command="{Binding ToggleLineNumbersCommand}"/>
+    </UserControl.KeyBindings>
+
     <DockPanel>
         <Menu DockPanel.Dock="Top" Name="MainMenu">
             <MenuItem Header="_File">
                 <MenuItem Header="_New Workspace" Command="{Binding NewWorkspaceCommand}" />
                 <MenuItem Header="_Open Workspace" Command="{Binding OpenWorkspaceCommand}" />
-                <!--Click="OnOpenWorkSpace"-->
                 <MenuItem Header="_Recent Workspaces" Name="RecentlyUsed"
                           ItemsSource="{Binding RecentWorkspaces}"
                           Command="{Binding OpenRecentWorkspaceCommand}"
@@ -37,25 +53,25 @@
                     </MenuItem.ItemTemplate>
                 </MenuItem>
 
-                <MenuItem Header="_Save" Command="{Binding SaveWorkspaceCommand}" HotKey="Ctrl+S" />
-                <MenuItem Header="Save _As" Command="{Binding SaveWorkspaceAsCommand}" HotKey="Ctrl+Shift+S" />
+                <MenuItem Header="_Save" Command="{Binding SaveWorkspaceCommand}" />
+                <MenuItem Header="Save _As" Command="{Binding SaveWorkspaceAsCommand}" />
             </MenuItem>
             <MenuItem Header="_Preferences">
                 <MenuItem Header="Application Options" Command="{Binding OpenAppPreferencesCommand}" />
                 <MenuItem Header="Workspace Options" Command="{Binding OpenWorkspacePreferencesCommand}" />
                 <Separator />
-                <MenuItem Header="Decrease FontSize" HotKey="Ctrl+9" Command="{Binding ChangeFontSizeCommand}">
+                <MenuItem Header="Decrease FontSize" Command="{Binding ChangeFontSizeCommand}">
                     <MenuItem.CommandParameter>
                         <system:Int32>-1</system:Int32>
                     </MenuItem.CommandParameter>
                 </MenuItem>
-                <MenuItem Header="Increase FontSize" HotKey="Ctrl+0" Command="{Binding ChangeFontSizeCommand}">
+                <MenuItem Header="Increase FontSize" Command="{Binding ChangeFontSizeCommand}">
                     <MenuItem.CommandParameter>
                         <system:Int32>1</system:Int32>
                     </MenuItem.CommandParameter>
                 </MenuItem>
-                <MenuItem Header="Toggle word-wrap" HotKey="Alt+Z" Command="{Binding ToggleWordWrapCommand}" />
-                <MenuItem Header="Toggle line-numbers" HotKey="Alt+N" Command="{Binding ToggleLineNumbersCommand}" />
+                <MenuItem Header="Toggle word-wrap" Command="{Binding ToggleWordWrapCommand}" />
+                <MenuItem Header="Toggle line-numbers" Command="{Binding ToggleLineNumbersCommand}" />
 
             </MenuItem>
             <MenuItem Header="Misc">
@@ -139,7 +155,10 @@
                 Background="{DynamicResource SystemAltMediumColor}"
                 Grid.Row="1"
                 Grid.ColumnSpan="3">
-                <TextBlock Text="{Binding UpdateInfo}" />
+                <TextBlock
+                    Text="{Binding UpdateInfo}"
+                    IsVisible="{Binding ShowUpdateInfo}"
+                    Margin="5"/>
             </StackPanel>
         </Grid>
     </DockPanel>

--- a/applications/lokqlDx-Av/Views/MainView.axaml.cs
+++ b/applications/lokqlDx-Av/Views/MainView.axaml.cs
@@ -13,43 +13,11 @@ namespace LokqlDx.Views;
 [DependencyProperty<RowDefinitions>(
     "RowDefinitions",
     DefaultBindingMode = DefaultBindingMode.TwoWay)]
-public partial class MainView : UserControl, IDisposable
+public partial class MainView : UserControl
 {
     public MainView()
     {
         InitializeComponent();
-    }
-
-    protected override void OnDataContextChanged(EventArgs e)
-    {
-        base.OnDataContextChanged(e);
-        if (DataContext is MainViewModel mvm)
-        {
-            mvm.PropertyChanged += Mvm_PropertyChanged;
-        }
-    }
-
-    private void Mvm_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
-    {
-        if (DataContext is MainViewModel mvm)
-        {
-            if (e.PropertyName == nameof(MainViewModel.ColumnDefinitions) && mvm.ColumnDefinitions is not null)
-            {
-                MainGrid.ColumnDefinitions = mvm.ColumnDefinitions;
-            }
-            else if (e.PropertyName == nameof(MainViewModel.RowDefinitions) && mvm.RowDefinitions is not null)
-            {
-                MainGrid.RowDefinitions = mvm.RowDefinitions;
-            }
-        }
-    }
-
-    public void Dispose()
-    {
-        if (DataContext is MainViewModel mvm)
-        {
-            mvm.PropertyChanged -= Mvm_PropertyChanged;
-        }
     }
 
     partial void OnColumnDefinitionsChanged(ColumnDefinitions? newValue)

--- a/applications/lokqlDx-Av/Views/MainWindow.axaml
+++ b/applications/lokqlDx-Av/Views/MainWindow.axaml
@@ -9,7 +9,7 @@
         Icon="/Assets/avalonia-logo.ico"
         Title="{Binding WindowTitle, FallbackValue='lokqlDx'}"
         TransparencyLevelHint="Mica,AcrylicBlur,Blur"
-        Background="{DynamicResource SystemListLowColor}"
+        Background="{DynamicResource SystemAltMediumHighColor}"
         x:DataType="vm:MainViewModel"
         PositionChanged="Window_PositionChanged"
         SizeChanged="Window_SizeChanged"

--- a/applications/lokqlDx-Av/Views/MainWindow.axaml.cs
+++ b/applications/lokqlDx-Av/Views/MainWindow.axaml.cs
@@ -2,6 +2,7 @@
 using Avalonia.Controls;
 using LokqlDx.ViewModels;
 using DependencyPropertyGenerator;
+using Avalonia.Media;
 
 namespace LokqlDx.Views;
 
@@ -22,6 +23,11 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
         Content = view;
+
+        if (ActualTransparencyLevel == WindowTransparencyLevel.Mica)
+        {
+            Background = Brushes.Transparent;
+        }
     }
 
     private void Window_PositionChanged(object? sender, PixelPointEventArgs e)


### PR DESCRIPTION
Hotkeys for menu items should be working now.

While loading UI preferences I've added a fallback in case e.g. selected font family was removed since a last time using an app, or if running on other OSes.

For AcrylicBlur, Blur and None transparency levels window background is {DynamicResource SystemAltMediumHighColor}, for Mica it is transparent