### PR TITLE
Trigger file autocompletion only with file IO commands

### DIFF
--- a/applications/lokqlDx/ViewModels/QueryEditorViewModel.cs
+++ b/applications/lokqlDx/ViewModels/QueryEditorViewModel.cs
@@ -118,7 +118,8 @@ public partial class QueryEditorViewModel : ObservableObject, IDisposable
         InternalCommands = verbs.Select(v =>
                 new IntellisenseEntry(v.Name, v.HelpText, string.Empty))
             .ToArray();
-        Parser = new CommandParser(verbs.Select(x => x.Name), ".");
+        var fileIoCommands = verbs.Where(x => x.SupportsFiles).Select(x => x.Name);
+        Parser = new CommandParser(fileIoCommands, ".");
     }
     public string GetText() => Document.Text;
 


### PR DESCRIPTION
Small bugfix, forgot to filter down permitted commands we pass down to the parser...

```csharp
var fileIoCommands = verbs.Where(x => x.SupportsFiles).Select(x => x.Name);
Parser = new CommandParser(fileIoCommands, ".");
```