### PR TITLE
Integrate NLog into DI

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,6 +48,8 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.9.3" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.9.3" />
+    <PackageVersion Include="NLog.Extensions.Logging" Version="6.0.1" />
+    <PackageVersion Include="NLog.Layouts.ClefJsonLayout" Version="1.0.3" />
     <PackageVersion Include="NotNullStrings" Version="1.0.1" />
     <PackageVersion Include="OpenAI" Version="2.2.0" />
     <PackageVersion Include="Parquet.Net" Version="5.1.1" />

--- a/applications/lokqlDx/appsettings.Development.json
+++ b/applications/lokqlDx/appsettings.Development.json
@@ -1,0 +1,12 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug"
+    }
+  },
+  "File": {
+    "LogLevel": {
+      "Default": "Trace"
+    }
+  }
+}

--- a/applications/lokqlDx/lokqlDx.csproj
+++ b/applications/lokqlDx/lokqlDx.csproj
@@ -16,6 +16,7 @@
     <ApplicationIcon>Assets\kql.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
+    <None CopyToOutputDirectory="Always" Update="appsettings.Development.json" />
     <None Remove="Assets\CompletionIcons\column.svg" />
     <None Remove="Assets\CompletionIcons\command.svg" />
     <None Remove="Assets\CompletionIcons\csv.svg" />
@@ -116,4 +117,5 @@
       <DependentUpon>QueryEditorView.axaml</DependentUpon>
     </Compile>
   </ItemGroup>
+
 </Project>

--- a/libraries/LogSetup/ILoggingModule.cs
+++ b/libraries/LogSetup/ILoggingModule.cs
@@ -13,9 +13,5 @@ public interface ILoggingModule
 {
     public static IConfiguration GetConfiguration() => Host.CreateApplicationBuilder().Configuration;
 
-    public static ILoggerFactory GetLoggerFactory(IConfiguration configuration) => LoggerFactory.Create(x => x
-        .AddConfiguration(configuration.GetSection("Logging"))
-        .AddConsole()
-        .AddDebug()
-    );
+    public static ILoggerFactory GetLoggerFactory(IConfiguration configuration) => LoggerFactoryProvider.GetFactory(configuration);
 }

--- a/libraries/LogSetup/LogSetup.csproj
+++ b/libraries/LogSetup/LogSetup.csproj
@@ -11,6 +11,8 @@
     <PackageReference Include="Jab" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="NLog"  />
+    <PackageReference Include="NLog.Extensions.Logging" />
+    <PackageReference Include="NLog.Layouts.ClefJsonLayout" />
   </ItemGroup>
 
 </Project>

--- a/libraries/LogSetup/LoggerFactoryProvider.cs
+++ b/libraries/LogSetup/LoggerFactoryProvider.cs
@@ -1,0 +1,175 @@
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using NLog;
+using NLog.Extensions.Logging;
+using NLog.Layouts;
+using NLog.Layouts.ClefJsonLayout;
+using NLog.Targets;
+using NLogLevel = NLog.LogLevel;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+namespace LogSetup;
+
+public class LoggerFactoryProvider
+{
+    public static ILoggerFactory GetFactory(IConfiguration configuration)
+    {
+        // callsite: does not work because of logging extension wrapper methods ("LoggingExtensions.Log")
+        var firstLine = """
+                        ${time}
+                        ${level:uppercase=true}
+                        [32m${logger:shortName=true}[0m
+                        | ${message:raw=true:withException=true:exceptionSeparator=|}
+                        """.ReplaceLineEndings(" ");
+
+
+        var compoundLayout = new CompoundLayout
+        {
+            Layouts =
+            {
+                firstLine,
+                new InternalJsonLayout()
+            }
+        };
+
+        var defaultLevel = GetLogLevel(configuration, "Logging:LogLevel:Default", LogLevel.Information);
+
+        var consoleLevel = GetLogLevel(configuration, "Console:LogLevel:Default", defaultLevel);
+        var debugLevel = GetLogLevel(configuration, "Debug:LogLevel:Default", defaultLevel);
+        var fileLevel = GetLogLevel(configuration, "File:LogLevel:Default", defaultLevel);
+        var consoleNLogLevel = ToNLogLevel(consoleLevel);
+        var debugNLogLevel = ToNLogLevel(debugLevel);
+        var fileNLogLevel = ToNLogLevel(fileLevel);
+        var logPath = configuration["File:Path"] ?? Path.Combine(Path.GetTempPath(), "kusto-loco.log");
+        Console.WriteLine($"Logging to {logPath}");
+
+        var factory = LogManager
+            .Setup()
+            .LoadConfiguration(b =>
+                {
+                    b
+                        .ForLogger()
+                        .FilterMinLevel(consoleNLogLevel)
+                        .WriteTo(new ColoredConsoleTarget
+                            {
+                                Layout = compoundLayout,
+                                UseDefaultRowHighlightingRules = false,
+                                Encoding = Encoding.UTF8,
+                                EnableAnsiOutput = true,
+                                WordHighlightingRules =
+                                {
+                                    new(NLogLevel.Trace.ToString().ToUpper(),
+                                        ConsoleOutputColor.Gray,
+                                        ConsoleOutputColor.NoChange
+                                    ),
+                                    new(NLogLevel.Debug.ToString().ToUpper(),
+                                        ConsoleOutputColor.White,
+                                        ConsoleOutputColor.NoChange
+                                    ),
+                                    new(NLogLevel.Info.ToString().ToUpper(),
+                                        ConsoleOutputColor.Cyan,
+                                        ConsoleOutputColor.NoChange
+                                    ),
+                                    new(NLogLevel.Warn.ToString().ToUpper(),
+                                        ConsoleOutputColor.Yellow,
+                                        ConsoleOutputColor.NoChange
+                                    ),
+                                    new(NLogLevel.Error.ToString().ToUpper(),
+                                        ConsoleOutputColor.Red,
+                                        ConsoleOutputColor.NoChange
+                                    ),
+                                    new(NLogLevel.Fatal.ToString().ToUpper(),
+                                        ConsoleOutputColor.DarkRed,
+                                        ConsoleOutputColor.White
+                                    )
+                                }
+                            }
+                        );
+                    b
+                        .ForLogger()
+                        .FilterMinLevel(debugNLogLevel)
+                        .WriteToDebugConditional(compoundLayout);
+
+                    b
+                        .ForLogger()
+                        .FilterMinLevel(fileNLogLevel)
+                        .WriteToFile(logPath,
+                            new CompactJsonLayout
+                            {
+                                IncludeEventProperties = true,
+                                IncludeScopeProperties = true,
+                                RenderEmptyObject = false,
+                                MaxRecursionLimit = 3
+                            },
+                            Encoding.UTF8,
+                            maxArchiveDays: 30,
+                            maxArchiveFiles: 3,
+                            archiveAboveSize: 10 * (int)Math.Pow(1024, 2)
+                        );
+                }
+            )
+            .LogFactory;
+
+
+        return new NLogLoggerFactory(new NLogLoggerProvider(
+                new NLogProviderOptions
+                {
+                    IncludeScopes = true,
+                    CaptureMessageProperties = true,
+                    CaptureMessageTemplates = true,
+                    CaptureMessageParameters = true
+                },
+                factory
+            )
+        );
+    }
+
+    private static LogLevel GetLogLevel(IConfiguration configuration, string configSection, LogLevel defaultLogLevel)
+    {
+        var logLevel = configuration[configSection] ?? "";
+        var level = defaultLogLevel;
+        if (Enum.TryParse<LogLevel>(logLevel, true, out var level2))
+        {
+            level = level2;
+        }
+
+        return level;
+    }
+
+    private static NLogLevel ToNLogLevel(LogLevel level)
+    {
+        var nlogLevel = level switch
+        {
+            LogLevel.None => NLogLevel.Off,
+            LogLevel.Trace => NLogLevel.Trace,
+            LogLevel.Debug => NLogLevel.Debug,
+            LogLevel.Information => NLogLevel.Info,
+            LogLevel.Warning => NLogLevel.Warn,
+            LogLevel.Error => NLogLevel.Error,
+            LogLevel.Critical => NLogLevel.Fatal,
+            _ => NLogLevel.Off
+        };
+        return nlogLevel;
+    }
+}
+
+/// <summary>
+/// Renders properties on an indented new line if there are any.
+/// </summary>
+file class InternalJsonLayout : Layout
+{
+    private readonly JsonLayout _layout = new()
+    {
+        IncludeEventProperties = true,
+        IncludeScopeProperties = true,
+        RenderEmptyObject = false,
+        MaxRecursionLimit = 1
+    };
+
+    protected override string GetFormattedMessage(LogEventInfo logEvent)
+    {
+        var res = _layout.Render(logEvent);
+        return res is "" ? "" : $"{Environment.NewLine}  {res}";
+    }
+}


### PR DESCRIPTION
<img width="675" height="76" alt="image" src="https://github.com/user-attachments/assets/4b526ece-14fd-453a-afd7-b1397ed95f5b" />

This PR integrates NLog into DI

This was originally part of a bigger PR since I originally thought I was going to have to work out how configs were going to work with our DI solution, logging, and the assembly to use for assets. That's no longer a concern with the new approach in #370 so this is trivial.

I set up configuration to be similar to that of how Microsoft's [default logging configuration](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-9.0) works. No significant changes otherwise.