### PR TITLE
Add array_iif function and it's tests

### DIFF
--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
@@ -285,7 +285,7 @@ internal static class BuiltInScalarFunctions
         BenchmarkFunction.Register(Functions);
         ParTest.Register(Functions);
         DateTimeKindFunction.Register(Functions);
-        
+        ArrayIifFunction.Register(Functions);
 
       
     }

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/ArrayIif.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/ArrayIif.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Text.Json.Nodes;
+using System.Linq;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl
+{
+    [KustoImplementation(Keyword = "array_iif")]
+    internal partial class ArrayIifFunction
+    {
+        public JsonNode? Impl(JsonNode condArray, JsonNode array1, JsonNode array2)
+        {
+            if (condArray is not JsonArray conds || array1 is not JsonArray arr1 || array2 is not JsonArray arr2)
+                return null;
+            var result = new JsonArray();
+
+            for (int i = 0; i < conds.Count; i++)
+            {
+                bool? cond = null;
+                if (conds[i] is JsonValue v)
+                {
+                    if (v.TryGetValue<bool>(out var b)) cond = b;
+                    else if (v.TryGetValue<int>(out var e)) cond = e != 0;
+                    else if (v.TryGetValue<long>(out var l)) cond = l != 0;
+                    else if (v.TryGetValue<double>(out var d)) cond = d != 0.0;
+                }
+
+                JsonNode? val1;
+                JsonNode? val2;
+
+                if (arr1.Count == 1 && arr2.Count == 1)
+                {
+                    val1 = arr1[0];
+                    val2 = arr2[0];
+                }
+                else
+                {
+                    val1 = i < arr1.Count ? arr1[i] : "null";
+                    val2 = i < arr2.Count ? arr2[i] : "null";
+                }
+
+                if (cond is null)
+                    result.Add(JsonValue.Create("null"));
+                else
+                {
+                    var val = (cond.Value ? val1 : val2);
+                    if (val is JsonValue jv)
+                        result.Add(jv.GetValue<object>() ?? JsonValue.Create((object?)null));
+                    else
+                        result.Add(val ?? JsonValue.Create((object?)null));
+                }
+            }
+            return result;
+        } 
+    }
+}

--- a/test/BasicTests/SimpleFunctionTests.cs
+++ b/test/BasicTests/SimpleFunctionTests.cs
@@ -307,7 +307,7 @@ datatable(Size:int) [50]
         var result = await LastLineOfResult(query);
         result.Should().Be("55");
     }
-   
+
 
     [TestMethod]
     public async Task RangeTimeSpan()
@@ -813,6 +813,7 @@ print toscalar(letters | summarize mx=min(bitmap));";
     {
         var query = "print strrep('ABC', 2)";
         var result = await LastLineOfResult(query);
+
         result.Should().Be("ABCABC");
     }
 
@@ -1226,6 +1227,9 @@ print toscalar(letters | summarize mx=min(bitmap));";
         res.Should().Contain("null");
     }
 
+
+
+
     [TestMethod]
     public async Task BuiltIns_isnull_Columnar()
     {
@@ -1250,4 +1254,59 @@ print toscalar(letters | summarize mx=min(bitmap));";
         result.Should().Be(expected);
     }
 
+    [TestMethod]
+    public async Task array_iif()
+    {
+        // query1
+        var query = """
+                    print condition=dynamic([true,false,true]), if_true=dynamic([1,2,3]), if_false=dynamic([4,5,6]) 
+                    | extend res= array_iif(condition, if_true, if_false)
+                    | extend res_str = strcat_array(res, ",")
+                    | project res_str
+                    """;
+        var expected = "1,5,3";
+        var res = await LastLineOfResult(query);
+
+        res.Should().Be(expected);
+        
+        // query2
+        var query2 = """
+                    print condition=dynamic([1,0,50]), if_true = dynamic(["yes"]), if_false=dynamic(["no"]) 
+                    | extend res= array_iif(condition, if_true, if_false)
+                    | extend res_str = strcat_array(res, ",")
+                    | project res_str
+                    """;
+        var expected2 = "yes,no,yes";
+        var res2 = await LastLineOfResult(query2);
+        res2.Should().Be(expected2);
+
+        // //query 3
+        var query3 = """
+                    print condition=dynamic(["some string value", "datetime(01-01-2022)", null]), if_true=dynamic(["1"]), if_false=dynamic(["0"])
+                    | extend res= array_iif(condition, if_true, if_false)
+                    | extend res_str = strcat_array(res, ",")
+                    | project res_str
+                    """;
+        var expected3 = "null,null,null";
+        var res3 = await LastLineOfResult(query3);
+        res3.Should().Be(expected3);
+
+
+        // query 4
+        var query4 = """
+                    print condition=dynamic([true,true,true]), if_true=dynamic([1,2]), if_false=dynamic([3,4]) 
+                    | extend res= array_iif(condition, if_true, if_false)
+                    | extend res_str = strcat_array(res, ",")
+                    | project res_str
+                    """;
+        var expected4 = "1,2,\"null\"";
+        var res4 = await LastLineOfResult(query4);
+        res4.Should().Be(expected4);
+
+    }
+
+
+
 }
+
+   


### PR DESCRIPTION
Have added `ArrayIif.cs` file containing `array_if` function implementation. Implements a null-safe element-wise selection from two arrays based on a condition array. Handles scalars, mixed types, and nulls. (for #398 issue)