### PR TITLE
Further improvements to lokql

### DIFF
--- a/applications/lokql/CmdConvert.cs
+++ b/applications/lokql/CmdConvert.cs
@@ -1,0 +1,31 @@
+﻿using CommandLine;
+using NLog;
+
+/// <summary>
+///     Interactive data explorer
+/// </summary>
+internal class CmdConvert
+{
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+
+    public static async Task RunAsync(Options options)
+    {
+        var explorer = await Explorer.Create(options.Data, options.Args, options.Load,
+            options.Commands, options.Scripts);
+        await explorer.RunInput($".load \"{options.In}\"");
+        await explorer.RunInput($".save \"{options.Out}\"");
+        explorer.Close();
+    }
+
+    [Verb("convert",  HelpText = "Converts a data file into another format ")]
+    public class Options : CommonOptions
+    {
+        [Option('i', Required = true, HelpText = "Input file")]
+        public string In { get; set; } = string.Empty;
+        [Option('o', Required = true, HelpText = "Output file")]
+        public string Out { get; set; } = string.Empty;
+        [Option('f', Required = false, HelpText = "Format")]
+        public string Format { get; set; } = string.Empty;
+    }
+}

--- a/applications/lokql/CmdExplore.cs
+++ b/applications/lokql/CmdExplore.cs
@@ -1,10 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Net.Quic;
-using System.Text;
-using CommandLine;
-using KustoLoco.Core.Console;
-using KustoLoco.Core.Settings;
-using Lokql.Engine;
+﻿using CommandLine;
 using NLog;
 
 /// <summary>
@@ -17,32 +11,15 @@ internal class CmdExplore
 
     public static async Task RunAsync(Options options)
     {
-        var explorer = new Explorer(options.Data, options.Args);
+        var explorer = await Explorer.Create(options.Data, options.Args, options.Load,
+            options.Commands, ((CommonOptions)options).Scripts);
         await explorer.RunInteractive();
         explorer.Close();
     }
-    
 
-    [Verb("explore", HelpText = "explore data source(s)")]
-    public class Options
+
+    [Verb("explore", HelpText = "runs scripts and/or commands then stays in interactive mode")]
+    public class Options : CommonOptions
     {
-        [Option(HelpText = "Folder containing '.dfr' scripts")]
-        public string Scripts { get; set; } = string.Empty;
-
-        [Option(HelpText = "Folder containing '.csl' scripts")]
-        public string Queries { get; set; } = string.Empty;
-
-        [Option(HelpText = "Default folder to load/save data/results to")]
-        public string Data { get; set; } = string.Empty;
-
-        [Option(HelpText = "Default folder for Scripts,Queries, Data if those aren't specified")]
-        public string WorkIn { get; set; } = string.Empty;
-
-
-        [Option(HelpText = "Runs a script at startup")]
-        public string Run { get; set; } = string.Empty;
-
-        [Option("args", HelpText = "Passes arguments to the script as arg0, arg1 etc")]
-        public IEnumerable<string> Args { get; set; } = [];
     }
 }

--- a/applications/lokql/CmdRun.cs
+++ b/applications/lokql/CmdRun.cs
@@ -11,36 +11,17 @@ internal class CmdRun
 
     public static async Task RunAsync(Options options)
     {
-        var explorer = new Explorer(options.Data, options.Args);
-        foreach (var block in options.Commands)
-            await explorer.RunInput(block);
-        foreach (var f in options.Files)
-            try
-            {
-                var block = await File.ReadAllTextAsync(f);
-                await explorer.RunInput(block);
-            }
-            catch (IOException)
-            {
-                explorer.Error("Unable to load file '{f}'");
-            }
+        var explorer = await Explorer.Create(options.Data, options.Args,options.Load,
+            options.Commands,options.Scripts);
+       
 
         explorer.Close();
     }
 
-    [Verb("run", true, HelpText = "runs a lokqldx workspace in its entirety")]
-    public class Options
+    [Verb("run", true, HelpText = "runs scripts and/or commands")]
+    public class Options :CommonOptions
     {
-        [Option(HelpText = "Default folder to load/save data/results to")]
-        public string Data { get; set; } = string.Empty;
+      
 
-        [Option('f', HelpText = "Runs a script or sequence of scripts")]
-        public IEnumerable<string> Files { get; set; } = [];
-
-        [Option('c', HelpText = "Runs a command or sequence of commands")]
-        public IEnumerable<string> Commands { get; set; } = [];
-
-        [Option("args", HelpText = "Passes arguments to the script as arg0, arg1 etc")]
-        public IEnumerable<string> Args { get; set; } = [];
     }
 }

--- a/applications/lokql/CommonOptions.cs
+++ b/applications/lokql/CommonOptions.cs
@@ -1,0 +1,19 @@
+﻿using CommandLine;
+
+public class CommonOptions
+{
+    [Option(HelpText = "Default folder to load/save data/results to")]
+    public string Data { get; set; } = ".";
+
+    [Option("args", HelpText = "Passes arguments to the script as arg0, arg1 etc")]
+    public IEnumerable<string> Args { get; set; } = [];
+    [Option('f', HelpText = "Runs a script or sequence of scripts")]
+    public IEnumerable<string> Scripts { get; set; } = [];
+
+    [Option('c', HelpText = "Runs a command or sequence of commands")]
+    public IEnumerable<string> Commands { get; set; } = [];
+
+    [Option('l', HelpText = "Loads data files")]
+    public IEnumerable<string> Load { get; set; } = [];
+
+}

--- a/applications/lokql/Explorer.cs
+++ b/applications/lokql/Explorer.cs
@@ -8,16 +8,43 @@ public class Explorer
     private readonly IKustoConsole _console;
     private readonly InteractiveTableExplorer _explorer;
 
-    public Explorer(string dataFolder, IEnumerable<string> args)
+    private Explorer(string dataFolder, IEnumerable<string> args)
     {
         _console = new SystemConsole();
         var settings = new KustoSettingsProvider();
+       
         settings.Set(StandardFormatAdaptor.Settings.KustoDataPath.Name, dataFolder);
         foreach (var (i, a) in args.Index()) settings.Set($"arg{i}", a);
 
         var processor = CommandProcessorProvider.GetCommandProcessor();
         var renderer = new SixelRenderingSurface(settings);
         _explorer = new InteractiveTableExplorer(_console, settings, processor, renderer, []);
+      
+    }
+
+    public static async Task<Explorer> Create(string dataFolder, IEnumerable<string> args,
+        IEnumerable<string> dataFiles,
+        IEnumerable<string> commands,
+        IEnumerable<string> scripts)
+    {
+        var r = new Explorer(dataFolder, args);
+        foreach (var datafile in dataFiles)
+        {
+            await r.RunInput($".load \"{datafile}\"");
+        }
+        foreach (var block in commands)
+            await r.RunInput(block);
+        foreach (var f in scripts)
+            try
+            {
+                var block = await File.ReadAllTextAsync(f);
+                await r.RunInput(block);
+            }
+            catch (IOException)
+            {
+                r.Error("Unable to load script '{f}'");
+            }
+        return r;
     }
 
     public void Close() => _console.RestoreColors();

--- a/applications/lokql/Program.cs
+++ b/applications/lokql/Program.cs
@@ -7,8 +7,10 @@ LoggingExtensions.SetupLoggingForConsole(LogLevel.Info);
 await StandardParsers.Default
         .ParseArguments(args,
             typeof(CmdExplore.Options),
-            typeof(CmdRun.Options)
+            typeof(CmdRun.Options),
+            typeof(CmdConvert.Options)
         )
         .WithParsedAsync<CmdExplore.Options>(CmdExplore.RunAsync)
         .WithParsedAsync<CmdRun.Options>(CmdRun.RunAsync)
+        .WithParsedAsync<CmdConvert.Options>(CmdConvert.RunAsync)
     ;

--- a/applications/lokql/SixelRenderingSurface.cs
+++ b/applications/lokql/SixelRenderingSurface.cs
@@ -8,7 +8,7 @@ using Spectre.Console;
 internal class SixelRenderingSurface(KustoSettingsProvider settings)
     : IResultRenderingSurface
 {
-    private const string SettingName = "table.maxrows";
+    private const string MaxRowsSetting = "table.maxrows";
     private const int DefaultRows = 100;
 
     public async Task RenderToDisplay(KustoQueryResult result)
@@ -40,7 +40,7 @@ internal class SixelRenderingSurface(KustoSettingsProvider settings)
 
         // Add columns with header names
         foreach (var column in queryResult.ColumnDefinitions()) table.AddColumn(column.Name);
-        var maxRows = settings.GetIntOr(SettingName, DefaultRows);
+        var maxRows = settings.GetIntOr(MaxRowsSetting, DefaultRows);
         // Add rows.  Note that cells could contain nulls in the general case
         foreach (var row in queryResult.EnumerateRows().Take(maxRows))
         {
@@ -52,8 +52,7 @@ internal class SixelRenderingSurface(KustoSettingsProvider settings)
         if (maxRows < queryResult.RowCount)
         {
             Console.ForegroundColor = ConsoleColor.Yellow;
-            AnsiConsole.WriteLine($"Only {maxRows} of {queryResult.RowCount} shown.");
-            AnsiConsole.WriteLine($"Set {SettingName} to see more");
+            AnsiConsole.WriteLine($"Only {maxRows} of {queryResult.RowCount} shown.  Set {MaxRowsSetting} to see more");
         }
 
         return;

--- a/libraries/KustoLoco.Core/KustoFormatter.cs
+++ b/libraries/KustoLoco.Core/KustoFormatter.cs
@@ -39,7 +39,7 @@ public static class KustoFormatter
     }
 
     public static string Tabulate(KustoQueryResult result, int max = int.MaxValue)
-        => Tabulate(result, new DisplayPreferences(int.MaxValue, 0, max));
+        => Tabulate(result, new DisplayPreferences(int.MaxValue, 0, max,false));
 
     public static string Tabulate(KustoQueryResult result, DisplayPreferences preferences)
     {
@@ -55,8 +55,10 @@ public static class KustoFormatter
         var screenWidth = Math.Max(10, preferences.ScreenWidth);
 
 
+        string[] ColumnHeader(ColumnResult c) => preferences.HideColumnHeaders ? [] : [c.Name];
+
         string[] MakeStringColumn(ColumnResult c)
-            => new[] { c.Name }
+            => ColumnHeader(c)
                 .Concat(result.EnumerateColumnData(c)
                     .Skip(preferences.StartOffset)
                     .Take(max))
@@ -77,12 +79,12 @@ public static class KustoFormatter
             .Select(PadToMax)
             .ToArray();
 
-
-        for (var r = 0; r <= displayHeight; r++)
+        var displayRows = preferences.HideColumnHeaders ? displayHeight : displayHeight + 1;
+        for (var r = 0; r < displayRows; r++)
         {
             var line = cells.Select(c => c[r]).ToArray();
             sb.AppendLine(JoinToLine(line));
-            if (r == 0)
+            if (!preferences.HideColumnHeaders && r == 0)
             {
                 var dividerLine = line.Select(c => "".PadRight(c.Length, '-'));
                 sb.AppendLine(JoinToLine(dividerLine));
@@ -104,5 +106,5 @@ public static class KustoFormatter
         }
     }
 
-    public readonly record struct DisplayPreferences(int ScreenWidth, int StartOffset, int Length);
+    public readonly record struct DisplayPreferences(int ScreenWidth, int StartOffset, int Length,bool HideColumnHeaders);
 }

--- a/libraries/KustoLoco.Core/Settings/KustoSettingsProvider.cs
+++ b/libraries/KustoLoco.Core/Settings/KustoSettingsProvider.cs
@@ -187,6 +187,10 @@ public class KustoSettingsProvider
         var s = Get(setting).ToLowerInvariant();
         return trueValues.Contains(s);
     }
+    public bool GetBool(string settingName)
+    {
+        return GetBool(new KustoSettingDefinition(settingName, string.Empty, "0", "bool"));
+    }
 
     /// <summary>
     /// Enumerates all current settings as <see cref="RawKustoSetting"/> values.

--- a/libraries/ScottPlotRendering/ScottPlotKustoResultRenderer.cs
+++ b/libraries/ScottPlotRendering/ScottPlotKustoResultRenderer.cs
@@ -447,6 +447,16 @@ public static class ScottPlotKustoResultRenderer
         int linesAtEnd)
     {
         var (width, height) = TerminalHelper.GetScreenDimension(linesAtEnd);
+        var widthFactor=  settings.GetDoubleOr("sixel.width",0.9);
+        var heightFactor = settings.GetDoubleOr("sixel.height", 0.9);
+        width = widthFactor > 10.0
+            ? (int) widthFactor
+            : (int) (width * widthFactor);
+
+        height = heightFactor > 10.0
+            ? (int)heightFactor
+            : (int)(height * heightFactor);
+
         return RenderToSixel(result, settings, width, height);
     }
 

--- a/libraries/lokql-engine/Commands/SaveCommand.cs
+++ b/libraries/lokql-engine/Commands/SaveCommand.cs
@@ -15,6 +15,7 @@ public static class SaveCommand
         {
             newLayer.Set("csv.skipheader", "true");
             newLayer.Set("tsv.skipheader", "true");
+            newLayer.Set("txt.skipheader", "true");
         }
         var exp = context.Explorer;
         exp.Settings.AddLayer(newLayer);
@@ -38,7 +39,7 @@ Examples:
         public string File { get; set; } = string.Empty;
         [Value(1, HelpText = "Name of result (or most recent result if left blank)")]
         public string ResultName { get; set; } = string.Empty;
-        [Option(HelpText = "Avoid writing headers for csv and text files")]
+        [Option('n',HelpText = "Avoid writing headers for csv and text files")]
         public bool NoHeader { get; set; }
     }
 }

--- a/libraries/lokql-engine/InteractiveTableExplorer.cs
+++ b/libraries/lokql-engine/InteractiveTableExplorer.cs
@@ -99,7 +99,7 @@ public class InteractiveTableExplorer
         _outputConsole.ForegroundColor = ConsoleColor.Green;
 
 
-        var prefs = new KustoFormatter.DisplayPreferences(_outputConsole.WindowWidth, start, maxToDisplay);
+        var prefs = new KustoFormatter.DisplayPreferences(_outputConsole.WindowWidth, start, maxToDisplay,false);
         _outputConsole.WriteLine(KustoFormatter.Tabulate(result, prefs));
 
         if (maxToDisplay < result.RowCount)

--- a/libraries/lokql-engine/TextTableAdaptor.cs
+++ b/libraries/lokql-engine/TextTableAdaptor.cs
@@ -1,8 +1,9 @@
-﻿using System.Collections.Immutable;
-using KustoLoco.Core;
+﻿using KustoLoco.Core;
 using KustoLoco.Core.Console;
 using KustoLoco.Core.Settings;
 using KustoLoco.FileFormats;
+using System.Collections.Immutable;
+using static KustoLoco.Core.KustoFormatter;
 
 
 namespace Lokql.Engine;
@@ -23,7 +24,9 @@ public class TextTableAdaptor : IFileBasedTableAccess
     {
         try
         {
-            var text = KustoFormatter.Tabulate(result);
+            var skipHeader = _settings.GetBool("txt.skipheader");
+            var prefs = new DisplayPreferences(int.MaxValue, 0, int.MaxValue, skipHeader);
+            var text = KustoFormatter.Tabulate(result,prefs);
             File.WriteAllText(path, text);
             return Task.FromResult(true);
         }


### PR DESCRIPTION
 - Add "convert" command
- More commonlity between "run" and "explore"
- Allow data files to be loaded at startup
- Chart size can be controlled with sixel.width/height
- --noheader correctly skips header for text files