### PR TITLE
feat: bag-pack-variadic

### DIFF
--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
@@ -321,7 +321,7 @@ internal static class BuiltInScalarFunctions
         RegexQuoteFunction.Register(Functions);
         RepeatFunction.Register(Functions);
 
-        BagPackFunction.Register(Functions);
-        Functions.Add(Kusto.Language.Functions.Pack, BagPackFunction.S); // pack() is an alias for bag_pack()
+        //can't generate because arbitrary number of arguments
+        BagPackFunctionImpl.Register(Functions);
     }
 }

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/BagPackFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/BagPackFunction.cs
@@ -1,77 +1,82 @@
-﻿//
+//
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Nodes;
+using Kusto.Language;
+using Kusto.Language.Symbols;
+using KustoLoco.Core.DataSource;
+using KustoLoco.Core.DataSource.Columns;
 
 namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
 
-/// <summary>
-/// Implements the bag_pack (also known as pack) function.
-/// Creates a dynamic object (property bag) from a key-value pair.
-/// Note: The full Kusto bag_pack supports multiple key-value pairs (bag_pack(key1, value1, key2, value2, ...)),
-/// but this implementation currently supports a single key-value pair which is sufficient for common use cases.
-/// pack() and pack_dictionary() are deprecated aliases of bag_pack()
-/// </summary>
-[KustoImplementation(Keyword = "Functions.BagPack")]
-internal partial class BagPackFunction
+internal class BagPackFunctionImpl : IScalarFunctionImpl
 {
-    private static JsonNode? Impl(string key, string value)
+    private const int MaxPairs = 32;
+
+    public ScalarResult InvokeScalar(ScalarResult[] arguments)
     {
         var bag = new JsonObject();
-        if (!string.IsNullOrEmpty(key))
+        for (var i = 0; i + 1 < arguments.Length; i += 2)
         {
-            bag[key] = JsonValue.Create(value);
+            if (arguments[i].Value is not string key || string.IsNullOrEmpty(key))
+                continue;
+            bag[key] = ToJsonNode(arguments[i + 1].Value);
         }
-        return bag;
+        return new ScalarResult(ScalarTypes.Dynamic, (JsonNode?)bag);
     }
 
-    private static JsonNode? JsonImpl(string key, JsonNode? value)
+    public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
     {
-        var bag = new JsonObject();
-        if (!string.IsNullOrEmpty(key))
+        var rowCount = arguments[0].Column.RowCount;
+        var data = NullableSetBuilderOfJsonNode.CreateFixed(rowCount);
+        for (var row = 0; row < rowCount; row++)
         {
-            bag[key] = value?.DeepClone();
+            var bag = new JsonObject();
+            for (var i = 0; i + 1 < arguments.Length; i += 2)
+            {
+                if (arguments[i].Column.GetRawDataValue(row) is not string key || string.IsNullOrEmpty(key))
+                    continue;
+                bag[key] = ToJsonNode(arguments[i + 1].Column.GetRawDataValue(row));
+            }
+            data[row] = bag;
         }
-        return bag;
+        return new ColumnarResult(GenericColumnFactoryOfJsonNode.CreateFromDataSet(data.ToNullableSet()));
     }
 
-    private static JsonNode? IntImpl(string key, int value)
+    private static JsonNode? ToJsonNode(object? value) => value switch
     {
-        var bag = new JsonObject();
-        if (!string.IsNullOrEmpty(key))
-        {
-            bag[key] = JsonValue.Create(value);
-        }
-        return bag;
+        null => null,
+        JsonNode node => node.DeepClone(),
+        string s => JsonValue.Create(s),
+        int i => JsonValue.Create(i),
+        long l => JsonValue.Create(l),
+        double d => JsonValue.Create(d),
+        decimal dec => JsonValue.Create(dec),
+        bool b => JsonValue.Create(b),
+        DateTime dt => JsonValue.Create(dt),
+        TimeSpan ts => JsonValue.Create(ts.ToString()),
+        Guid g => JsonValue.Create(g),
+        _ => JsonValue.Create(value.ToString())
+    };
+
+    internal static void Register(Dictionary<FunctionSymbol, ScalarFunctionInfo> functions)
+    {
+        var overloads = Enumerable.Range(1, MaxPairs)
+            .Select(BuildOverloadForPairCount)
+            .ToArray();
+        var info = new ScalarFunctionInfo(overloads);
+        functions.Add(Functions.BagPack, info);
+        functions.Add(Functions.Pack, info); // pack() is a deprecated alias for bag_pack()
     }
 
-    private static JsonNode? LongImpl(string key, long value)
+    private static ScalarOverloadInfo BuildOverloadForPairCount(int pairCount)
     {
-        var bag = new JsonObject();
-        if (!string.IsNullOrEmpty(key))
-        {
-            bag[key] = JsonValue.Create(value);
-        }
-        return bag;
-    }
-
-    private static JsonNode? DoubleImpl(string key, double value)
-    {
-        var bag = new JsonObject();
-        if (!string.IsNullOrEmpty(key))
-        {
-            bag[key] = JsonValue.Create(value);
-        }
-        return bag;
-    }
-
-    private static JsonNode? BoolImpl(string key, bool value)
-    {
-        var bag = new JsonObject();
-        if (!string.IsNullOrEmpty(key))
-        {
-            bag[key] = JsonValue.Create(value);
-        }
-        return bag;
+        var parameterTypes = Enumerable.Range(0, pairCount)
+            .SelectMany(_ => new[] { ScalarTypes.String, ScalarTypes.Unknown })
+            .ToArray();
+        return new ScalarOverloadInfo(new BagPackFunctionImpl(), ScalarTypes.Dynamic, parameterTypes);
     }
 }

--- a/test/BasicTests/AggregationFunctionTests.cs
+++ b/test/BasicTests/AggregationFunctionTests.cs
@@ -37,6 +37,77 @@ public class AggregationFunctionTests : TestMethods
         result.Should().Contain("\"key1\":\"value1\"");
     }
 
+    [TestMethod]
+    public async Task BagPack_MultipleStringPairs()
+    {
+        var query = "print bag_pack('a', 'one', 'b', 'two', 'c', 'three')";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Be("{\"a\":\"one\",\"b\":\"two\",\"c\":\"three\"}");
+    }
+
+    [TestMethod]
+    public async Task BagPack_MixedValueTypes()
+    {
+        var query = "print bag_pack('name', 'kusto', 'count', 42, 'ratio', 0.5, 'active', true)";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Contain("\"name\":\"kusto\"");
+        result.Should().Contain("\"count\":42");
+        result.Should().Contain("\"ratio\":0.5");
+        result.Should().Contain("\"active\":true");
+    }
+
+    [TestMethod]
+    public async Task BagPack_FromColumnsBuildsListOfBags()
+    {
+        // matches the make_list / bag_pack composition described in the issue:
+        // each row is packed into a dynamic bag and then aggregated via make_list.
+        var query = @"
+datatable(Name:string, Value:int, Status:string)
+[
+    'alpha', 1, 'ok',
+    'beta',  2, 'fail',
+]
+| extend Item = bag_pack('name', Name, 'value', Value, 'status', Status)
+| summarize Items = make_list(Item)
+";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Contain("{\"name\":\"alpha\",\"value\":1,\"status\":\"ok\"}");
+        result.Should().Contain("{\"name\":\"beta\",\"value\":2,\"status\":\"fail\"}");
+    }
+
+    [TestMethod]
+    public async Task BagPack_EmptyKeyPairIsSkipped()
+    {
+        var query = "print bag_pack('', 'ignored', 'kept', 'yes')";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Be("{\"kept\":\"yes\"}");
+    }
+
+    [TestMethod]
+    public async Task BagPack_NestedDynamicValueIsPreserved()
+    {
+        var query = "print bag_pack('outer', bag_pack('inner', 1))";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Be("{\"outer\":{\"inner\":1}}");
+    }
+
+    [TestMethod]
+    public async Task BagPack_NullValueIsSerializedAsNull()
+    {
+        var query = "print bag_pack('missing', dynamic(null), 'present', 1)";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Be("{\"missing\":null,\"present\":1}");
+    }
+
+    [TestMethod]
+    public async Task BagPack_DateTimeAndTimeSpanValues()
+    {
+        var query = "print bag_pack('ts', datetime(2024-01-02T03:04:05Z), 'dur', 5m)";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Contain("\"ts\":\"2024-01-02T");
+        result.Should().Contain("\"dur\":\"00:05:00\"");
+    }
+
     #endregion
 
     #region make_bag tests


### PR DESCRIPTION
First: Thanks a lot for this great library!

This PR will introduce support for multiple key/value pairs in bag_pack.
The single-pair limitation forced me to use workarrounds for common Kusto patterns. Now you can use:

`| extend Item = bag_pack("name", Name, "value", Value, "status", Status)
| summarize Items = make_list(Item)`

which will return a propert list of property bags. make_list / make_bag / summarize -> need no changes.

Added 7 additional Unit test for this PR and you existing single-pair tests continue to pass.