### PR TITLE
feat: add bag_merge and pack_all

### DIFF
--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
@@ -323,5 +323,6 @@ internal static class BuiltInScalarFunctions
 
         //can't generate because arbitrary number of arguments
         BagPackFunctionImpl.Register(Functions);
+        BagMergeFunctionImpl.Register(Functions);
     }
 }

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
@@ -324,5 +324,6 @@ internal static class BuiltInScalarFunctions
         //can't generate because arbitrary number of arguments
         BagPackFunctionImpl.Register(Functions);
         BagMergeFunctionImpl.Register(Functions);
+        PackAllFunctionImpl.Register(Functions);
     }
 }

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/BagMergeFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/BagMergeFunction.cs
@@ -1,0 +1,65 @@
+//
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+using Kusto.Language;
+using Kusto.Language.Symbols;
+using KustoLoco.Core.DataSource;
+using KustoLoco.Core.DataSource.Columns;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+internal class BagMergeFunctionImpl : IScalarFunctionImpl
+{
+    private const int MinBags = 2;
+    private const int MaxBags = 64;
+
+    public ScalarResult InvokeScalar(ScalarResult[] arguments)
+    {
+        var bag = new JsonObject();
+        foreach (var argument in arguments)
+            MergeInto(bag, argument.Value);
+        return new ScalarResult(ScalarTypes.Dynamic, (JsonNode?)bag);
+    }
+
+    public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+    {
+        var rowCount = arguments[0].Column.RowCount;
+        var data = NullableSetBuilderOfJsonNode.CreateFixed(rowCount);
+        for (var row = 0; row < rowCount; row++)
+        {
+            var bag = new JsonObject();
+            foreach (var argument in arguments)
+                MergeInto(bag, argument.Column.GetRawDataValue(row));
+            data[row] = bag;
+        }
+        return new ColumnarResult(GenericColumnFactoryOfJsonNode.CreateFromDataSet(data.ToNullableSet()));
+    }
+
+    // Leftmost-arg wins on key collision (matches ADX bag_merge and the make_bag aggregate).
+    private static void MergeInto(JsonObject target, object? value)
+    {
+        if (value is not JsonObject source) return;
+        foreach (var kvp in source)
+        {
+            if (target.ContainsKey(kvp.Key)) continue;
+            target[kvp.Key] = kvp.Value?.DeepClone();
+        }
+    }
+
+    internal static void Register(Dictionary<FunctionSymbol, ScalarFunctionInfo> functions)
+    {
+        var overloads = Enumerable.Range(MinBags, MaxBags - MinBags + 1)
+            .Select(BuildOverloadForBagCount)
+            .ToArray();
+        functions.Add(Functions.BagMerge, new ScalarFunctionInfo(overloads));
+    }
+
+    private static ScalarOverloadInfo BuildOverloadForBagCount(int bagCount)
+    {
+        var parameterTypes = Enumerable.Repeat(ScalarTypes.Dynamic, bagCount).ToArray();
+        return new ScalarOverloadInfo(new BagMergeFunctionImpl(), ScalarTypes.Dynamic, parameterTypes);
+    }
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/PackAllFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/PackAllFunction.cs
@@ -1,0 +1,97 @@
+//
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+using Kusto.Language;
+using Kusto.Language.Symbols;
+using KustoLoco.Core.DataSource;
+using KustoLoco.Core.DataSource.Columns;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+internal class PackAllFunctionImpl : IScalarFunctionImpl
+{
+    private const int MaxColumns = 128;
+
+    public ScalarResult InvokeScalar(ScalarResult[] arguments)
+    {
+        var ignoreNullEmpty = arguments.Length > 0 && arguments[0].Value is bool b && b;
+        var bag = new JsonObject();
+        for (var i = 1; i + 1 < arguments.Length; i += 2)
+        {
+            if (arguments[i].Value is not string key) continue;
+            var value = arguments[i + 1].Value;
+            if (ignoreNullEmpty && IsNullOrEmpty(value)) continue;
+            bag[key] = ToJsonNode(value);
+        }
+        return new ScalarResult(ScalarTypes.Dynamic, (JsonNode?)bag);
+    }
+
+    public ColumnarResult InvokeColumnar(ColumnarResult[] arguments)
+    {
+        var rowCount = arguments[0].Column.RowCount;
+        var ignoreNullEmpty = rowCount > 0 && arguments[0].Column.GetRawDataValue(0) is bool b && b;
+        var data = NullableSetBuilderOfJsonNode.CreateFixed(rowCount);
+        for (var row = 0; row < rowCount; row++)
+        {
+            var bag = new JsonObject();
+            for (var i = 1; i + 1 < arguments.Length; i += 2)
+            {
+                if (arguments[i].Column.GetRawDataValue(row) is not string key) continue;
+                var value = arguments[i + 1].Column.GetRawDataValue(row);
+                if (ignoreNullEmpty && IsNullOrEmpty(value)) continue;
+                bag[key] = ToJsonNode(value);
+            }
+            data[row] = bag;
+        }
+        return new ColumnarResult(GenericColumnFactoryOfJsonNode.CreateFromDataSet(data.ToNullableSet()));
+    }
+
+    private static bool IsNullOrEmpty(object? value) => value switch
+    {
+        null => true,
+        string s => s.Length == 0,
+        JsonObject obj => obj.Count == 0,
+        JsonArray arr => arr.Count == 0,
+        _ => false
+    };
+
+    private static JsonNode? ToJsonNode(object? value) => value switch
+    {
+        null => null,
+        JsonNode node => node.DeepClone(),
+        string s => JsonValue.Create(s),
+        int i => JsonValue.Create(i),
+        long l => JsonValue.Create(l),
+        double d => JsonValue.Create(d),
+        decimal dec => JsonValue.Create(dec),
+        bool b => JsonValue.Create(b),
+        DateTime dt => JsonValue.Create(dt),
+        TimeSpan ts => JsonValue.Create(ts.ToString()),
+        Guid g => JsonValue.Create(g),
+        _ => JsonValue.Create(value.ToString())
+    };
+
+    internal static void Register(Dictionary<FunctionSymbol, ScalarFunctionInfo> functions)
+    {
+        var overloads = Enumerable.Range(0, MaxColumns + 1)
+            .Select(BuildOverloadForColumnCount)
+            .ToArray();
+        functions.Add(Functions.PackAll, new ScalarFunctionInfo(overloads));
+    }
+
+    private static ScalarOverloadInfo BuildOverloadForColumnCount(int columnCount)
+    {
+        var parameterTypes = new TypeSymbol[1 + columnCount * 2];
+        parameterTypes[0] = ScalarTypes.Bool;
+        for (var i = 0; i < columnCount; i++)
+        {
+            parameterTypes[1 + i * 2] = ScalarTypes.String;
+            parameterTypes[2 + i * 2] = ScalarTypes.Unknown;
+        }
+        return new ScalarOverloadInfo(new PackAllFunctionImpl(), ScalarTypes.Dynamic, parameterTypes);
+    }
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/ToDateTimeFmtFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/ToDateTimeFmtFunction.cs
@@ -6,5 +6,8 @@ namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
 [KustoImplementation(Keyword = "todatetimefmt")]
 internal partial class ToDateTimeFmtFunction
 {
-    private static DateTime? Impl(string input,string fmt) => DateTime.TryParseExact(input,fmt,CultureInfo.InvariantCulture, DateTimeStyles.None,out var result) ? result.ToUniversalTime() : null;
+    private static DateTime? Impl(string input, string fmt) =>
+        DateTime.TryParseExact(input, fmt, CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out var result) ? result : null;
 }

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/todatetimefunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/todatetimefunction.cs
@@ -10,6 +10,7 @@ namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
 internal partial class ToDateTimeFunction
 {
     private static DateTime? Impl(string input) =>
-        DateTime.TryParse(input,CultureInfo.GetCultureInfo("en-GB"),
-            out var result) ? result.ToUniversalTime() : null;
+        DateTime.TryParse(input, CultureInfo.GetCultureInfo("en-GB"),
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out var result) ? result : null;
 }

--- a/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.Expressions.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.Expressions.cs
@@ -319,6 +319,12 @@ internal partial class IRTranslator : DefaultSyntaxVisitor<IRNode>
         }
 
         var functionSymbol = (FunctionSymbol)signature.Symbol;
+        if (functionSymbol == Functions.PackAll)
+        {
+            irArguments = ExpandPackAllArguments(irArguments);
+            parameters = BuildPackAllParameters(irArguments.Length);
+        }
+
         if (FunctionFinder.TryGetOverload(_functions, functionSymbol, returnType, irArguments, parameters,
                 out var functionOverload))
         {
@@ -402,5 +408,34 @@ internal partial class IRTranslator : DefaultSyntaxVisitor<IRNode>
     {
         var irExpression = (IRExpressionNode)node.Expression.Accept(this);
         return new IRToScalarExpressionNode(irExpression, node.ResultType);
+    }
+
+    // pack_all's source signature is (ignore_null_empty?: bool); the IR expansion appends
+    // one (name, value) pair per row-scope column so a registered overload can resolve it.
+    private IRExpressionNode[] ExpandPackAllArguments(IRExpressionNode[] irArguments)
+    {
+        var flag = irArguments.Length == 0
+            ? new IRLiteralExpressionNode(false, ScalarTypes.Bool)
+            : irArguments[0];
+
+        var expanded = new List<IRExpressionNode>(1 + _rowScope.Members.Count * 2) { flag };
+        for (var i = 0; i < _rowScope.Members.Count; i++)
+        {
+            if (_rowScope.Members[i] is not ColumnSymbol column) continue;
+            expanded.Add(new IRLiteralExpressionNode(column.Name, ScalarTypes.String));
+            expanded.Add(new IRRowScopeNameReferenceNode(column, column.Type, i));
+        }
+        return expanded.ToArray();
+    }
+
+    private static List<Parameter> BuildPackAllParameters(int argumentCount)
+    {
+        var parameters = new List<Parameter>(argumentCount) { new("ignore_null_empty", ScalarTypes.Bool) };
+        for (var i = 1; i + 1 < argumentCount; i += 2)
+        {
+            parameters.Add(new Parameter("key", ScalarTypes.String));
+            parameters.Add(new Parameter("value", ScalarTypes.Unknown));
+        }
+        return parameters;
     }
 }

--- a/test/BasicTests/AggregationFunctionTests.cs
+++ b/test/BasicTests/AggregationFunctionTests.cs
@@ -110,6 +110,97 @@ datatable(Name:string, Value:int, Status:string)
 
     #endregion
 
+    #region bag_merge tests
+
+    [TestMethod]
+    public async Task BagMerge_TwoDisjointBags()
+    {
+        var query = "print bag_merge(bag_pack('a', 1), bag_pack('b', 2))";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Be("{\"a\":1,\"b\":2}");
+    }
+
+    [TestMethod]
+    public async Task BagMerge_LeftmostArgWinsOnConflict()
+    {
+        var query = "print bag_merge(bag_pack('k', 'first'), bag_pack('k', 'last'))";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Be("{\"k\":\"first\"}");
+    }
+
+    [TestMethod]
+    public async Task BagMerge_ThreeBags()
+    {
+        var query = "print bag_merge(bag_pack('a', 1), bag_pack('b', 2), bag_pack('c', 3))";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Be("{\"a\":1,\"b\":2,\"c\":3}");
+    }
+
+    [TestMethod]
+    public async Task BagMerge_LeftmostWinsAcrossThreeBags()
+    {
+        var query = "print bag_merge(bag_pack('k', 1), bag_pack('k', 2), bag_pack('k', 3))";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Be("{\"k\":1}");
+    }
+
+    [TestMethod]
+    public async Task BagMerge_EmptyBag()
+    {
+        var query = "print bag_merge(dynamic({}), bag_pack('a', 1))";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Be("{\"a\":1}");
+    }
+
+    [TestMethod]
+    public async Task BagMerge_NullBagIsSkipped()
+    {
+        var query = "print bag_merge(dynamic(null), bag_pack('a', 1))";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Be("{\"a\":1}");
+    }
+
+    [TestMethod]
+    public async Task BagMerge_NonObjectArgIsSkipped()
+    {
+        // Non-object dynamic values flow through dynamic-typed columns; the impl skips them.
+        var query = @"
+datatable(b:dynamic)
+[
+    dynamic([1,2,3]),
+]
+| summarize merged = bag_merge(dynamic({""kept"":1}), take_any(b))
+";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Be("{\"kept\":1}");
+    }
+
+    [TestMethod]
+    public async Task BagMerge_NestedBagsArePreserved()
+    {
+        var query = "print bag_merge(bag_pack('outer', bag_pack('inner', 1)), bag_pack('other', 2))";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Be("{\"outer\":{\"inner\":1},\"other\":2}");
+    }
+
+    [TestMethod]
+    public async Task BagMerge_FromColumns()
+    {
+        var query = @"
+datatable(b1:dynamic, b2:dynamic)
+[
+    dynamic({""a"":1}), dynamic({""b"":2}),
+    dynamic({""x"":10}), dynamic({""x"":20, ""y"":30}),
+]
+| extend Merged = bag_merge(b1, b2)
+| project Merged
+";
+        var result = Squash(await ResultAsString(query, "|"));
+        result.Should().Be("{\"a\":1,\"b\":2}|{\"x\":10,\"y\":30}");
+    }
+
+    #endregion
+
     #region make_bag tests
 
     [TestMethod]

--- a/test/BasicTests/AggregationFunctionTests.cs
+++ b/test/BasicTests/AggregationFunctionTests.cs
@@ -201,6 +201,126 @@ datatable(b1:dynamic, b2:dynamic)
 
     #endregion
 
+    #region pack_all tests
+
+    [TestMethod]
+    public async Task PackAll_NoArgs_PacksAllColumns()
+    {
+        var query = @"
+datatable(a:int, b:string) [1, 'x']
+| extend bag = pack_all()
+| project bag
+";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Be("{\"a\":1,\"b\":\"x\"}");
+    }
+
+    [TestMethod]
+    public async Task PackAll_PacksEachRowIndependently()
+    {
+        var query = @"
+datatable(a:int, b:string) [1, 'x', 2, 'y']
+| extend bag = pack_all()
+| project bag
+";
+        var result = Squash(await ResultAsString(query, "|"));
+        result.Should().Be("{\"a\":1,\"b\":\"x\"}|{\"a\":2,\"b\":\"y\"}");
+    }
+
+    [TestMethod]
+    public async Task PackAll_IgnoreNullEmpty_True_SkipsNullsAndEmpty()
+    {
+        var query = @"
+datatable(a:int, b:string, c:string)
+[
+    int(null), '', 'kept',
+]
+| extend bag = pack_all(true)
+| project bag
+";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Be("{\"c\":\"kept\"}");
+    }
+
+    [TestMethod]
+    public async Task PackAll_IgnoreNullEmpty_False_KeepsNulls()
+    {
+        var query = @"
+datatable(a:int, b:string)
+[
+    int(null), 'hi',
+]
+| extend bag = pack_all(false)
+| project bag
+";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Be("{\"a\":null,\"b\":\"hi\"}");
+    }
+
+    [TestMethod]
+    public async Task PackAll_NoRowScope_ReturnsEmptyBag()
+    {
+        var query = "print pack_all()";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Be("{}");
+    }
+
+    [TestMethod]
+    public async Task PackAll_DoesNotIncludeTargetExtendColumn()
+    {
+        var query = @"
+datatable(a:int, b:string) [1, 'x']
+| extend bag = pack_all()
+| project bag
+";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().NotContain("\"bag\"");
+    }
+
+    [TestMethod]
+    public async Task PackAll_IgnoreNullEmpty_True_SkipsEmptyDynamic()
+    {
+        var query = @"
+datatable(a:dynamic, b:dynamic)
+[
+    dynamic({}), dynamic({""x"":1}),
+]
+| extend bag = pack_all(true)
+| project bag
+";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Contain("\"b\":{\"x\":1}");
+        result.Should().NotContain("\"a\":{}");
+    }
+
+    [TestMethod]
+    public async Task PackAll_EmptyTableDoesNotThrow()
+    {
+        var query = @"
+datatable(a:int, b:string) []
+| extend bag = pack_all(true)
+| project bag
+| count
+";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Be("0");
+    }
+
+    [TestMethod]
+    public async Task PackAll_AfterProjectChangesRowScope()
+    {
+        var query = @"
+datatable(a:int, b:string, c:long) [1, 'x', 100]
+| project a, renamed=b
+| extend bag = pack_all()
+| project bag
+";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Be("{\"a\":1,\"renamed\":\"x\"}");
+    }
+
+    #endregion
+
     #region make_bag tests
 
     [TestMethod]

--- a/test/BasicTests/DateTimeTests.cs
+++ b/test/BasicTests/DateTimeTests.cs
@@ -238,10 +238,9 @@ public class DateTimeTests : TestMethods
     [TestMethod]
     public void DtCheck()
     {
-        var dt = DateTime.Parse("2 feb 2020 11:00");
-        dt.Kind.Should().Be(DateTimeKind.Unspecified);
-        var universal = dt.ToUniversalTime();
-        universal.Kind.Should().Be(DateTimeKind.Utc);
-        universal.ToString("g").Should().Be("02/02/2020 11:00");
+        var dt = DateTime.Parse("2 feb 2020 11:00", CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+        dt.Kind.Should().Be(DateTimeKind.Utc);
+        dt.ToString("g", CultureInfo.InvariantCulture).Should().Be("02/02/2020 11:00");
     }
 }


### PR DESCRIPTION
Adds missing `bag_merge()` and `pack_all()` support.

`pack_all()` is implemented as an IR translator rewrite because it needs access to the full current row scope, which the parser function signature does not expose.

Also fixes timezone-dependent `todatetime()` behavior: `.ToUniversalTime()` on `DateTimeKind.Unspecified` caused parsed datetimes to drift on non-UTC machines, such as Switzerland.

Includes tests for:
- `bag_merge()` merge/conflict behavior
- `pack_all()` row-scope and null/empty handling
- timezone-independent `todatetime()`


**Note:** This may change results for timezone-less datetime strings. Previously they were interpreted as local machine time via ToUniversalTime(); they are now interpreted as UTC to make evaluation deterministic across machines.