### PR TITLE
Add a provider seam for data-backed scalars + geo_info_from_ip_address / parse_user_agent (#613)

### DIFF
--- a/libraries/KustoLoco.Core/BabyKustoEngine.cs
+++ b/libraries/KustoLoco.Core/BabyKustoEngine.cs
@@ -27,6 +27,7 @@ public class BabyKustoEngine
     private Dictionary<FunctionSymbol, ScalarFunctionInfo> _additionalfuncs = new();
     private readonly IKustoConsole _console;
     private readonly KustoSettingsProvider _settings;
+    private ProviderRegistry _providers = new();
 
     public BabyKustoEngine(IKustoConsole console,KustoSettingsProvider settings)
     {
@@ -54,6 +55,17 @@ public class BabyKustoEngine
     {
         _additionalfuncs = funcs;
     }
+
+    // Register a host-supplied provider (for example an IGeoIpProvider) that context-aware scalar functions read at
+    // evaluation time. Absent providers leave their functions returning null (inert), so queries still run.
+    public BabyKustoEngine AddProvider<T>(T provider) where T : class
+    {
+        _providers.Set(provider);
+        return this;
+    }
+
+    // Use a caller-owned provider registry (e.g. one held by KustoQueryContext across query runs).
+    internal void UseProviders(ProviderRegistry providers) => _providers = providers;
 
     public IReadOnlyCollection<AggregateInfo> GetImplementedAggregateList()
     {
@@ -147,7 +159,7 @@ public class BabyKustoEngine
         var scope = new LocalScope();
         foreach (var table in tables) scope.AddSymbol(table.Type, TabularResult.CreateUnvisualized(table));
 
-        var result = BabyKustoEvaluator.Evaluate(ir, scope);
+        var result = BabyKustoEvaluator.Evaluate(ir, scope, _providers);
         return result;
     }
 

--- a/libraries/KustoLoco.Core/Evaluation/BabyKustoEvaluator.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BabyKustoEvaluator.cs
@@ -7,9 +7,9 @@ namespace KustoLoco.Core.Evaluation;
 
 internal static class BabyKustoEvaluator
 {
-    internal static EvaluationResult Evaluate(IRNode root, LocalScope scope)
+    internal static EvaluationResult Evaluate(IRNode root, LocalScope scope, IProviderRegistry? providers = null)
     {
         var evaluator = new TreeEvaluator();
-        return root.Accept(evaluator, new EvaluationContext(scope));
+        return root.Accept(evaluator, new EvaluationContext(scope) { Providers = providers });
     }
 }

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
@@ -352,5 +352,6 @@ internal static class BuiltInScalarFunctions
         SetIntersectFunctionImpl.Register(Functions);
         SetDifferenceFunctionImpl.Register(Functions);
         GeoInfoFromIpFunctionImpl.Register(Functions);
+        ParseUserAgentFunctionImpl.Register(Functions);
     }
 }

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
@@ -199,6 +199,10 @@ internal static class BuiltInScalarFunctions
         IsEmptyFunction.Register(Functions);
         IsNotEmptyFunction.Register(Functions);
         Ipv4IsPrivateFunction.Register(Functions);
+        Ipv4IsInRangeFunction.Register(Functions);
+        Ipv4IsInAnyRangeFunction.Register(Functions);
+        Ipv4IsMatchFunction.Register(Functions);
+        Ipv4CompareFunction.Register(Functions);
         ParseIpv4Function.Register(Functions);
         ParseIpv6Function.Register(Functions);
         IsAsciiFunction.Register(Functions);
@@ -320,6 +324,10 @@ internal static class BuiltInScalarFunctions
         UrlEncodeFunction.Register(Functions);
         RegexQuoteFunction.Register(Functions);
         RepeatFunction.Register(Functions);
+
+        SetHasElementFunction.Register(Functions);
+        BagKeysFunction.Register(Functions);
+        ExtractAllFunction.Register(Functions);
 
         //can't generate because arbitrary number of arguments
         BagPackFunctionImpl.Register(Functions);

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
@@ -207,6 +207,11 @@ internal static class BuiltInScalarFunctions
         FormatIpv4MaskFunction.Register(Functions);
         Ipv4NetmaskSuffixFunction.Register(Functions);
         ParseIpv4MaskFunction.Register(Functions);
+        Ipv4RangeToCidrListFunction.Register(Functions);
+        HasIpv4Function.Register(Functions);
+        HasIpv4PrefixFunction.Register(Functions);
+        HasAnyIpv4Function.Register(Functions);
+        HasAnyIpv4PrefixFunction.Register(Functions);
         ParseIpv4Function.Register(Functions);
         ParseIpv6Function.Register(Functions);
         IsAsciiFunction.Register(Functions);

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
@@ -337,5 +337,8 @@ internal static class BuiltInScalarFunctions
         BagPackFunctionImpl.Register(Functions);
         BagMergeFunctionImpl.Register(Functions);
         PackAllFunctionImpl.Register(Functions);
+        SetUnionFunctionImpl.Register(Functions);
+        SetIntersectFunctionImpl.Register(Functions);
+        SetDifferenceFunctionImpl.Register(Functions);
     }
 }

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
@@ -327,6 +327,10 @@ internal static class BuiltInScalarFunctions
 
         SetHasElementFunction.Register(Functions);
         BagKeysFunction.Register(Functions);
+        BagHasKeyFunction.Register(Functions);
+        BagRemoveKeysFunction.Register(Functions);
+        BagSetKeyFunction.Register(Functions);
+        BagZipFunction.Register(Functions);
         ExtractAllFunction.Register(Functions);
 
         //can't generate because arbitrary number of arguments

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
@@ -203,6 +203,10 @@ internal static class BuiltInScalarFunctions
         Ipv4IsInAnyRangeFunction.Register(Functions);
         Ipv4IsMatchFunction.Register(Functions);
         Ipv4CompareFunction.Register(Functions);
+        FormatIpv4Function.Register(Functions);
+        FormatIpv4MaskFunction.Register(Functions);
+        Ipv4NetmaskSuffixFunction.Register(Functions);
+        ParseIpv4MaskFunction.Register(Functions);
         ParseIpv4Function.Register(Functions);
         ParseIpv6Function.Register(Functions);
         IsAsciiFunction.Register(Functions);

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
@@ -351,5 +351,6 @@ internal static class BuiltInScalarFunctions
         SetUnionFunctionImpl.Register(Functions);
         SetIntersectFunctionImpl.Register(Functions);
         SetDifferenceFunctionImpl.Register(Functions);
+        GeoInfoFromIpFunctionImpl.Register(Functions);
     }
 }

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
@@ -332,6 +332,8 @@ internal static class BuiltInScalarFunctions
         BagSetKeyFunction.Register(Functions);
         BagZipFunction.Register(Functions);
         ExtractAllFunction.Register(Functions);
+        ParseUrlFunction.Register(Functions);
+        ParseUrlQueryFunction.Register(Functions);
 
         //can't generate because arbitrary number of arguments
         BagPackFunctionImpl.Register(Functions);

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInsHelper.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInsHelper.cs
@@ -120,11 +120,19 @@ internal static class BuiltInsHelper
         return false;
     }
 
+    // A context-aware scalar function receives the EvaluationContext (e.g. to reach a registered provider); every other
+    // function uses the existing context-free path unchanged.
+    private static ScalarResult InvokeScalarCtx(IScalarFunctionImpl impl, ScalarResult[] args, EvaluationContext ctx) =>
+        impl is IContextualScalarFunctionImpl c ? c.InvokeScalar(args, ctx) : impl.InvokeScalar(args);
+
+    private static ColumnarResult InvokeColumnarCtx(IScalarFunctionImpl impl, ColumnarResult[] args, EvaluationContext ctx) =>
+        impl is IContextualScalarFunctionImpl c ? c.InvokeColumnar(args, ctx) : impl.InvokeColumnar(args);
+
     private static EvaluationResult CreateResultForScalarInvocation(IScalarFunctionImpl impl,
-        EvaluationResult[] arguments, TypeSymbol expectedResultType)
+        EvaluationResult[] arguments, TypeSymbol expectedResultType, EvaluationContext context)
     {
         var scalarArgs = arguments.Cast<ScalarResult>().ToArray();
-        var result = impl.InvokeScalar(scalarArgs);
+        var result = InvokeScalarCtx(impl, scalarArgs, context);
         MyDebug.Assert(result.Type.Simplify() == expectedResultType.Simplify(),
             $"Evaluation produced wrong type {SchemaDisplay.GetText(result.Type)}, expected {SchemaDisplay.GetText(expectedResultType)}");
         return result;
@@ -167,7 +175,7 @@ internal static class BuiltInsHelper
 
 
     private static EvaluationResult CreateResultForColumnarInvocation(IScalarFunctionImpl impl,
-        EvaluationResult[] arguments, TypeSymbol expectedResultType, EvaluationHints hints)
+        EvaluationResult[] arguments, TypeSymbol expectedResultType, EvaluationHints hints, EvaluationContext context)
     {
         var columnarArgs = CreateResultArray(arguments);
 
@@ -188,26 +196,29 @@ internal static class BuiltInsHelper
         {
             var logicalRowCount = columnarArgs.Max(c => c.RowCount);
             columnarArgs = columnarArgs.Select(c => c.SliceToTopRow()).ToArray();
-            var topRowResult = impl.InvokeColumnar(columnarArgs);
+            var topRowResult = InvokeColumnarCtx(impl, columnarArgs, context);
             return topRowResult.Inflate(logicalRowCount);
         }
 
-        var result = impl.InvokeColumnar(columnarArgs);
+        var result = InvokeColumnarCtx(impl, columnarArgs, context);
         MyDebug.Assert(result.Type.Simplify() == expectedResultType.Simplify(),
             $"Evaluation produced wrong type {SchemaDisplay.GetText(result.Type)}, expected {SchemaDisplay.GetText(expectedResultType)}");
         return result;
     }
 
     // TODO: Support named parameters
-    public static Func<EvaluationResult[], EvaluationResult> GetScalarImplementation(IScalarFunctionImpl impl,
+    // The invocation now receives the EvaluationContext so a context-aware function can reach per-query state
+    // (e.g. a registered provider); context-free functions ignore it.
+    public static Func<EvaluationResult[], EvaluationContext, EvaluationResult> GetScalarImplementation(
+        IScalarFunctionImpl impl,
         EvaluatedExpressionKind resultKind,
         TypeSymbol expectedResultType, EvaluationHints hints) =>
         resultKind switch
         {
-            EvaluatedExpressionKind.Scalar => arguments =>
-                CreateResultForScalarInvocation(impl, arguments, expectedResultType),
-            EvaluatedExpressionKind.Columnar => arguments =>
-                CreateResultForColumnarInvocation(impl, arguments, expectedResultType, hints),
+            EvaluatedExpressionKind.Scalar => (arguments, context) =>
+                CreateResultForScalarInvocation(impl, arguments, expectedResultType, context),
+            EvaluatedExpressionKind.Columnar => (arguments, context) =>
+                CreateResultForColumnarInvocation(impl, arguments, expectedResultType, hints, context),
             _ => throw new InvalidOperationException($"Unexpected result kind {resultKind}")
         };
 

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/Infra/IContextualScalarFunctionImpl.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/Infra/IContextualScalarFunctionImpl.cs
@@ -1,0 +1,20 @@
+//
+// Licensed under the MIT License.
+
+using KustoLoco.Core.Evaluation;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns;
+
+/// <summary>
+///     A scalar function that also needs the per-query <see cref="EvaluationContext" /> (for example to reach a
+///     host-registered provider via <c>context.Providers</c>). A function implements this in addition to being a normal
+///     <see cref="IScalarFunctionImpl" />; when the evaluator sees it, it passes the context into the invocation. This
+///     realises the standing TODO to thread <see cref="EvaluationContext" /> into scalar invocation without changing the
+///     signature every other function depends on.
+/// </summary>
+internal interface IContextualScalarFunctionImpl
+{
+    ScalarResult InvokeScalar(ScalarResult[] arguments, EvaluationContext context);
+
+    ColumnarResult InvokeColumnar(ColumnarResult[] arguments, EvaluationContext context);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/BagHasKeyFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/BagHasKeyFunction.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// bag_has_key(bag, key) -> true iff the dynamic object has the given top-level key; null when 'bag' is not an object.
+[KustoImplementation(Keyword = "Functions.BagHasKey")]
+internal partial class BagHasKeyFunction
+{
+    private static bool? Impl(JsonNode bag, string key) => DynamicSetSupport.HasKey(bag, key);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/BagKeysFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/BagKeysFunction.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// bag_keys(bag) -> the top-level property names of a dynamic property bag as a string array; null when the argument is
+// not a dynamic object.
+[KustoImplementation(Keyword = "Functions.BagKeys")]
+internal partial class BagKeysFunction
+{
+    private static JsonNode? Impl(JsonNode bag) => DynamicSetSupport.Keys(bag);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/BagRemoveKeysFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/BagRemoveKeysFunction.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// bag_remove_keys(bag, keys) -> a copy of the dynamic object with the named top-level keys removed; null when the
+// arguments are not an object / array.
+[KustoImplementation(Keyword = "Functions.BagRemoveKeys")]
+internal partial class BagRemoveKeysFunction
+{
+    private static JsonNode? Impl(JsonNode bag, JsonNode keys) => DynamicSetSupport.RemoveKeys(bag, keys);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/BagSetKeyFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/BagSetKeyFunction.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// bag_set_key(bag, key, value) -> a copy of the dynamic object with 'key' set to 'value'; null when 'bag' is not an
+// object. The value argument is polymorphic in ADX, so one overload per scalar type.
+[KustoImplementation(Keyword = "Functions.BagSetKey")]
+internal partial class BagSetKeyFunction
+{
+    private static JsonNode? StringImpl(JsonNode bag, string key, string value) => DynamicSetSupport.SetKey(bag, key, JsonValue.Create(value));
+    private static JsonNode? LongImpl(JsonNode bag, string key, long value) => DynamicSetSupport.SetKey(bag, key, JsonValue.Create(value));
+    private static JsonNode? RealImpl(JsonNode bag, string key, double value) => DynamicSetSupport.SetKey(bag, key, JsonValue.Create(value));
+    private static JsonNode? BoolImpl(JsonNode bag, string key, bool value) => DynamicSetSupport.SetKey(bag, key, JsonValue.Create(value));
+    private static JsonNode? Impl(JsonNode bag, string key, JsonNode value) => DynamicSetSupport.SetKey(bag, key, value);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/BagZipFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/BagZipFunction.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// bag_zip(keys, values) -> a dynamic object pairing keys[i] with values[i]. Null when either argument is not a
+// dynamic array.
+[KustoImplementation(Keyword = "Functions.BagZip")]
+internal partial class BagZipFunction
+{
+    private static JsonNode? Impl(JsonNode keys, JsonNode values) => DynamicSetSupport.Zip(keys, values);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/DynamicSetSupport.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/DynamicSetSupport.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// Shared helpers for the dynamic bag/set scalars. A separate class because the source generator INLINES an Impl body,
+// so an Impl must not call a private same-class helper.
+internal static class DynamicSetSupport
+{
+    // bag_keys(bag) -> the top-level property names of a dynamic object as a string array; null when not an object.
+    public static JsonNode? Keys(JsonNode bag)
+    {
+        if (bag is not JsonObject o) return null;
+        var arr = new JsonArray();
+        foreach (var kv in o) arr.Add(kv.Key);
+        return arr;
+    }
+
+    // set_has_element membership by JSON value-equality: compare canonical JSON text so string / number / bool / nested
+    // all behave consistently. Null when the set argument is not a dynamic array.
+    public static bool? Has(JsonNode set, JsonNode? value)
+    {
+        if (set is not JsonArray arr) return null;
+        var target = value?.ToJsonString();
+        foreach (var el in arr)
+            if (string.Equals(el?.ToJsonString(), target, StringComparison.Ordinal)) return true;
+        return false;
+    }
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/DynamicSetSupport.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/DynamicSetSupport.cs
@@ -26,4 +26,50 @@ internal static class DynamicSetSupport
             if (string.Equals(el?.ToJsonString(), target, StringComparison.Ordinal)) return true;
         return false;
     }
+
+    // bag_has_key(bag, key) -> true iff the top-level key is present; null when the bag argument is not an object.
+    public static bool? HasKey(JsonNode bag, string key)
+    {
+        if (bag is not JsonObject o) return null;
+        return o.ContainsKey(key);
+    }
+
+    // bag_remove_keys(bag, keys) -> a copy of the bag without the named top-level keys; null when the arguments are not
+    // an object / array.
+    public static JsonNode? RemoveKeys(JsonNode bag, JsonNode keys)
+    {
+        if (bag is not JsonObject o || keys is not JsonArray arr) return null;
+        var clone = (JsonObject)o.DeepClone();
+        foreach (var k in arr)
+        {
+            var key = k?.ToString();
+            if (key != null) clone.Remove(key);
+        }
+        return clone;
+    }
+
+    // bag_set_key(bag, key, value) -> a copy of the bag with key set to value; null when the bag argument is not an
+    // object. A null bag key argument is a no-op copy.
+    public static JsonNode? SetKey(JsonNode bag, string? key, JsonNode? value)
+    {
+        if (bag is not JsonObject o) return null;
+        var clone = (JsonObject)o.DeepClone();
+        if (key != null) clone[key] = value?.DeepClone();
+        return clone;
+    }
+
+    // bag_zip(keys, values) -> an object pairing keys[i] with values[i]; a longer keys array pads with null, a longer
+    // values array ignores the surplus. Null when either argument is not a dynamic array.
+    public static JsonNode? Zip(JsonNode keys, JsonNode values)
+    {
+        if (keys is not JsonArray ka || values is not JsonArray va) return null;
+        var obj = new JsonObject();
+        for (var i = 0; i < ka.Count; i++)
+        {
+            var key = ka[i]?.ToString();
+            if (key == null) continue;
+            obj[key] = i < va.Count ? va[i]?.DeepClone() : null;
+        }
+        return obj;
+    }
 }

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/ExtractAllFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/ExtractAllFunction.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// extract_all(regex, source) / extract_all(regex, captureGroups, source) -> dynamic. ADX shape: 0 capture groups ->
+// the full matches; 1 group -> that group per match; >1 groups (or an explicit captureGroups list) -> an array of
+// arrays. A bad pattern or a match-timeout (ReDoS guard) -> null; no match -> an empty array.
+[KustoImplementation(Keyword = "Functions.ExtractAll")]
+internal partial class ExtractAllFunction
+{
+    private static JsonNode? Impl(string regex, string source) => ExtractAllSupport.Extract(regex, source, null);
+
+    private static JsonNode? GroupsImpl(string regex, JsonNode captureGroups, string source)
+        => ExtractAllSupport.Extract(regex, source, captureGroups);
+}
+
+// Separate class: the source generator inlines an Impl body, so an Impl must not call a private same-class helper.
+internal static class ExtractAllSupport
+{
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
+
+    public static JsonNode? Extract(string? pattern, string? source, JsonNode? captureGroups)
+    {
+        if (string.IsNullOrEmpty(pattern) || source is null) return null;
+        Regex rx;
+        try { rx = new Regex(pattern, RegexOptions.CultureInvariant, RegexTimeout); }
+        catch (ArgumentException) { return null; }
+
+        var matches = new List<Match>();
+        try { foreach (Match m in rx.Matches(source)) matches.Add(m); }
+        catch (RegexMatchTimeoutException) { return null; }
+        if (matches.Count == 0) return new JsonArray();
+
+        if (captureGroups is JsonArray wantedArr)
+        {
+            var wanted = new List<int>();
+            foreach (var el in wantedArr)
+            {
+                if (el is JsonValue v && v.TryGetValue<long>(out var l)) wanted.Add((int)l);
+                else if (el is JsonValue vs && vs.TryGetValue<string>(out var s) && int.TryParse(s, out var pi)) wanted.Add(pi);
+                else return null;
+            }
+            var outer = new JsonArray();
+            foreach (var m in matches)
+            {
+                var row = new JsonArray();
+                foreach (var g in wanted)
+                    row.Add(g >= 0 && g < m.Groups.Count && m.Groups[g].Success ? JsonValue.Create(m.Groups[g].Value) : null);
+                outer.Add(row);
+            }
+            return outer;
+        }
+
+        var groupCount = rx.GetGroupNumbers().Length - 1;   // minus the implicit whole-match group 0
+        var result = new JsonArray();
+        if (groupCount <= 0)
+            foreach (var m in matches) result.Add(JsonValue.Create(m.Value));
+        else if (groupCount == 1)
+            foreach (var m in matches) result.Add(m.Groups[1].Success ? JsonValue.Create(m.Groups[1].Value) : null);
+        else
+            foreach (var m in matches)
+            {
+                var row = new JsonArray();
+                for (var g = 1; g <= groupCount; g++)
+                    row.Add(m.Groups[g].Success ? JsonValue.Create(m.Groups[g].Value) : null);
+                result.Add(row);
+            }
+        return result;
+    }
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/FormatIpv4Function.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/FormatIpv4Function.cs
@@ -1,0 +1,10 @@
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// format_ipv4(ip [, prefix]) -> the network address masked to the effective prefix (default 32) as dotted-quad; null
+// when the address is unparseable or the prefix is out of range.
+[KustoImplementation(Keyword = "Functions.FormatIPV4")]
+internal partial class FormatIpv4Function
+{
+    private static string? Impl(string ip) => Ipv4Support.FormatV4(ip, null);
+    private static string? PrefixImpl(string ip, long prefix) => Ipv4Support.FormatV4(ip, prefix);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/FormatIpv4MaskFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/FormatIpv4MaskFunction.cs
@@ -1,0 +1,9 @@
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// format_ipv4_mask(ip, prefix) -> the masked network address in CIDR notation; null when the address is unparseable or
+// the prefix is out of range.
+[KustoImplementation(Keyword = "Functions.FormatIPV4Mask")]
+internal partial class FormatIpv4MaskFunction
+{
+    private static string? Impl(string ip, long prefix) => Ipv4Support.FormatV4Mask(ip, prefix);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/GeoInfoFromIpFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/GeoInfoFromIpFunction.cs
@@ -1,0 +1,62 @@
+//
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Net;
+using System.Text.Json.Nodes;
+using Kusto.Language;
+using Kusto.Language.Symbols;
+using KustoLoco.Core.DataSource;
+using KustoLoco.Core.DataSource.Columns;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// geo_info_from_ip_address(ip) -> dynamic { country, state, city, latitude, longitude } resolved by the
+// host-registered IGeoIpProvider (read from EvaluationContext.Providers). No provider registered, an unparseable
+// address, or an unresolved address all yield null, so geo predicates stay inert rather than failing the query. This
+// is a context-aware scalar (IContextualScalarFunctionImpl): the engine ships no geo database, the host supplies it.
+internal class GeoInfoFromIpFunctionImpl : IScalarFunctionImpl, IContextualScalarFunctionImpl
+{
+    // The context-free path is never taken (the evaluator routes context-aware impls to the context method); it exists
+    // for interface completeness and degrades to "no provider" -> null.
+    public ScalarResult InvokeScalar(ScalarResult[] arguments) => InvokeScalar(arguments, default);
+
+    public ColumnarResult InvokeColumnar(ColumnarResult[] arguments) => InvokeColumnar(arguments, default);
+
+    public ScalarResult InvokeScalar(ScalarResult[] arguments, EvaluationContext context)
+    {
+        var provider = context.Providers?.Get<IGeoIpProvider>();
+        return new ScalarResult(ScalarTypes.Dynamic, Lookup(provider, arguments[0].Value as string));
+    }
+
+    public ColumnarResult InvokeColumnar(ColumnarResult[] arguments, EvaluationContext context)
+    {
+        var provider = context.Providers?.Get<IGeoIpProvider>();
+        var rowCount = arguments[0].Column.RowCount;
+        var data = NullableSetBuilderOfJsonNode.CreateFixed(rowCount);
+        for (var row = 0; row < rowCount; row++)
+            data[row] = Lookup(provider, arguments[0].Column.GetRawDataValue(row) as string);
+        return new ColumnarResult(GenericColumnFactoryOfJsonNode.CreateFromDataSet(data.ToNullableSet()));
+    }
+
+    private static JsonNode? Lookup(IGeoIpProvider? provider, string? ip)
+    {
+        if (provider is null || string.IsNullOrEmpty(ip) || !IPAddress.TryParse(ip, out var address))
+            return null;
+        var info = provider.Lookup(address);
+        if (info is null) return null;
+        return new JsonObject
+        {
+            ["country"] = info.Country is null ? null : JsonValue.Create(info.Country),
+            ["state"] = info.State is null ? null : JsonValue.Create(info.State),
+            ["city"] = info.City is null ? null : JsonValue.Create(info.City),
+            ["latitude"] = info.Latitude is null ? null : JsonValue.Create(info.Latitude.Value),
+            ["longitude"] = info.Longitude is null ? null : JsonValue.Create(info.Longitude.Value),
+        };
+    }
+
+    internal static void Register(Dictionary<FunctionSymbol, ScalarFunctionInfo> functions) =>
+        functions.Add(Functions.IpGeoLocation,
+            new ScalarFunctionInfo(new ScalarOverloadInfo(
+                new GeoInfoFromIpFunctionImpl(), ScalarTypes.Dynamic, ScalarTypes.String)));
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/HasAnyIpv4Function.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/HasAnyIpv4Function.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// has_any_ipv4(source, ips) -> true iff 'source' contains ANY of the IPv4 addresses in the dynamic array as a term.
+[KustoImplementation(Keyword = "Functions.HasAnyIpv4")]
+internal partial class HasAnyIpv4Function
+{
+    private static bool? Impl(string source, JsonNode ips) => Ipv4Support.HasAny(source, ips, asPrefix: false);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/HasAnyIpv4PrefixFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/HasAnyIpv4PrefixFunction.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// has_any_ipv4_prefix(source, ip_prefixes) -> true iff 'source' contains an IPv4 term matching ANY of the prefixes in
+// the dynamic array.
+[KustoImplementation(Keyword = "Functions.HasAnyIpv4Prefix")]
+internal partial class HasAnyIpv4PrefixFunction
+{
+    private static bool? Impl(string source, JsonNode ipPrefixes) => Ipv4Support.HasAny(source, ipPrefixes, asPrefix: true);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/HasIpv4Function.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/HasIpv4Function.cs
@@ -1,0 +1,9 @@
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// has_ipv4(source, ip) -> true iff 'source' contains the IPv4 'ip' as a properly delimited term; null when 'ip' is not
+// a valid IPv4 address.
+[KustoImplementation(Keyword = "Functions.HasIpv4")]
+internal partial class HasIpv4Function
+{
+    private static bool? Impl(string source, string ip) => Ipv4Support.HasIp(source, ip);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/HasIpv4PrefixFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/HasIpv4PrefixFunction.cs
@@ -1,0 +1,9 @@
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// has_ipv4_prefix(source, ip_prefix) -> true iff 'source' contains an IPv4 term whose leading octets match 'ip_prefix'
+// (e.g. "10.1."); null when the prefix is malformed.
+[KustoImplementation(Keyword = "Functions.HasIpv4Prefix")]
+internal partial class HasIpv4PrefixFunction
+{
+    private static bool? Impl(string source, string ipPrefix) => Ipv4Support.HasIpPrefix(source, ipPrefix);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4CompareFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4CompareFunction.cs
@@ -1,0 +1,10 @@
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// ipv4_compare(ip1, ip2 [, prefix]) -> -1/0/1 comparing two IPv4 addresses over the effective prefix (default 32; each
+// operand may also carry its own /prefix). Null when either address is unparseable.
+[KustoImplementation(Keyword = "Functions.Ipv4Compare")]
+internal partial class Ipv4CompareFunction
+{
+    private static long? Impl(string ip1, string ip2) => Ipv4Support.MaskedCompare(ip1, ip2, null);
+    private static long? PrefixImpl(string ip1, string ip2, long prefix) => Ipv4Support.MaskedCompare(ip1, ip2, prefix);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4IsInAnyRangeFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4IsInAnyRangeFunction.cs
@@ -1,0 +1,37 @@
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// ipv4_is_in_any_range(ip, ranges) -> true iff the IPv4 'ip' is inside ANY of the CIDR ranges in the dynamic array;
+// false if in none; null when 'ip' is unparseable or 'ranges' is not a dynamic array.
+[KustoImplementation(Keyword = "Functions.Ipv4IsInAnyRange")]
+internal partial class Ipv4IsInAnyRangeFunction
+{
+    private static bool? Impl(string ip, JsonNode ranges)
+    {
+        if (string.IsNullOrEmpty(ip) || ranges is not JsonArray arr) return null;
+        if (!Ipv4Support.TryParse(ip, out var ipv)) return null;
+        foreach (var item in arr)
+        {
+            var cidr = item?.ToString();
+            if (string.IsNullOrEmpty(cidr)) continue;
+            uint basev;
+            int bits;
+            var slash = cidr.IndexOf('/');
+            if (slash < 0)
+            {
+                // a bare address in the list is an exact (/32) match, as in ADX.
+                if (!Ipv4Support.TryParse(cidr, out basev)) continue;
+                bits = 32;
+            }
+            else
+            {
+                if (!Ipv4Support.TryParse(cidr.Substring(0, slash), out basev)) continue;
+                if (!int.TryParse(cidr.Substring(slash + 1), out bits) || bits < 0 || bits > 32) continue;
+            }
+            var mask = bits == 0 ? 0u : 0xFFFFFFFFu << (32 - bits);
+            if ((ipv & mask) == (basev & mask)) return true;
+        }
+        return false;
+    }
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4IsInRangeFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4IsInRangeFunction.cs
@@ -1,0 +1,8 @@
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// ipv4_is_in_range(ip, ip_range) -> true iff the IPv4 'ip' is inside the CIDR 'ip_range'. Null on unparseable/malformed.
+[KustoImplementation(Keyword = "Functions.Ipv4IsInRange")]
+internal partial class Ipv4IsInRangeFunction
+{
+    private static bool? Impl(string ip, string cidr) => Ipv4Support.InRange(ip, cidr);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4IsMatchFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4IsMatchFunction.cs
@@ -1,0 +1,10 @@
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// ipv4_is_match(ip1, ip2 [, prefix]) -> true iff two IPv4 addresses match over the effective prefix (default 32; each
+// operand may also carry its own /prefix). Null when either address is unparseable.
+[KustoImplementation(Keyword = "Functions.Ipv4IsMatch")]
+internal partial class Ipv4IsMatchFunction
+{
+    private static bool? Impl(string ip1, string ip2) => Ipv4Support.MaskedEqual(ip1, ip2, null);
+    private static bool? PrefixImpl(string ip1, string ip2, long prefix) => Ipv4Support.MaskedEqual(ip1, ip2, prefix);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4NetmaskSuffixFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4NetmaskSuffixFunction.cs
@@ -1,0 +1,8 @@
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// ipv4_netmask_suffix(ip_range) -> the /suffix of a CIDR (32 when none present); null when the address is unparseable.
+[KustoImplementation(Keyword = "Functions.Ipv4NetmaskSuffix")]
+internal partial class Ipv4NetmaskSuffixFunction
+{
+    private static long? Impl(string ipRange) => Ipv4Support.NetmaskSuffix(ipRange);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4RangeToCidrListFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4RangeToCidrListFunction.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// ipv4_range_to_cidr_list(start_ip, end_ip) -> the minimal ordered array of CIDR blocks covering the inclusive range;
+// null when either address is unparseable or start > end.
+[KustoImplementation(Keyword = "Functions.Ipv4RangeToCidrList")]
+internal partial class Ipv4RangeToCidrListFunction
+{
+    private static JsonNode? Impl(string startIp, string endIp) => Ipv4Support.RangeToCidrList(startIp, endIp);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4Support.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4Support.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
+using System.Numerics;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
 
 namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
 
@@ -83,6 +86,72 @@ internal static class Ipv4Support
     {
         var v = MaskedValue(ip, prefix);
         return v is null ? null : (long)v.Value;
+    }
+
+    // ipv4_range_to_cidr_list: the minimal ordered list of CIDR blocks that exactly covers [start_ip, end_ip].
+    public static JsonNode? RangeToCidrList(string startIp, string endIp)
+    {
+        if (!TryParse(startIp, out var start) || !TryParse(endIp, out var end) || start > end) return null;
+        var result = new JsonArray();
+        ulong s = start;
+        ulong e = end;
+        while (s <= e)
+        {
+            // Largest block the current start is aligned for, capped by how many addresses remain.
+            var maxByAlign = s == 0 ? 32 : BitOperations.TrailingZeroCount((uint)s);
+            var maxByCount = BitOperations.Log2(e - s + 1);
+            var blockBits = (int)Math.Min(maxByAlign, maxByCount);
+            result.Add($"{UintToDotted((uint)s)}/{32 - blockBits}");
+            s += 1UL << blockBits;
+        }
+        return result;
+    }
+
+    // has_ipv4 / has_ipv4_prefix scan for IPv4 terms delimited by non-alphanumeric, non-dot characters (so a substring
+    // of a longer number or word is not a match), matching ADX term semantics.
+    private static readonly Regex Ipv4Term =
+        new(@"(?<![0-9A-Za-z.])(\d{1,3}\.){3}\d{1,3}(?![0-9A-Za-z.])", RegexOptions.CultureInvariant);
+
+    public static bool? HasIp(string? source, string ip)
+    {
+        if (source is null) return null;
+        if (!TryParse(ip, out var target)) return null;
+        foreach (Match m in Ipv4Term.Matches(source))
+            if (TryParse(m.Value, out var v) && v == target) return true;
+        return false;
+    }
+
+    public static bool? HasIpPrefix(string? source, string prefix)
+    {
+        if (source is null) return null;
+        var parts = (prefix ?? "").TrimEnd('.').Split('.');
+        if (parts.Length is 0 or > 4) return null;
+        var octets = new int[parts.Length];
+        for (var i = 0; i < parts.Length; i++)
+            if (!int.TryParse(parts[i], out octets[i]) || octets[i] < 0 || octets[i] > 255) return null;
+        foreach (Match m in Ipv4Term.Matches(source))
+        {
+            var cand = m.Value.Split('.');
+            if (cand.Length != 4) continue;
+            var ok = true;
+            for (var i = 0; i < octets.Length; i++)
+                if (!int.TryParse(cand[i], out var o) || o != octets[i]) { ok = false; break; }
+            if (ok) return true;
+        }
+        return false;
+    }
+
+    public static bool? HasAny(string? source, JsonNode needles, bool asPrefix)
+    {
+        if (source is null || needles is not JsonArray arr) return null;
+        foreach (var item in arr)
+        {
+            var needle = item?.ToString();
+            if (string.IsNullOrEmpty(needle)) continue;
+            var hit = asPrefix ? HasIpPrefix(source, needle) : HasIp(source, needle);
+            if (hit == true) return true;
+        }
+        return false;
     }
 
     public static bool? MaskedEqual(string a, string b, long? prefixArg)

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4Support.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4Support.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// Shared helpers for the ipv4_* family. A separate class because the source generator INLINES an Impl body, so an Impl
+// must not call a private same-class helper. IPv4 addresses are held as a big-endian uint for mask/compare arithmetic.
+internal static class Ipv4Support
+{
+    public static bool TryParse(string s, out uint value)
+    {
+        value = 0;
+        if (!IPAddress.TryParse(s, out var ip) || ip.AddressFamily != AddressFamily.InterNetwork) return false;
+        var b = ip.GetAddressBytes();
+        value = ((uint)b[0] << 24) | ((uint)b[1] << 16) | ((uint)b[2] << 8) | b[3];
+        return true;
+    }
+
+    // Split "a.b.c.d[/prefix]" into address + prefix (32 when no suffix; a malformed suffix -> 32).
+    public static int SplitPrefix(string token, out string ip)
+    {
+        var slash = token.IndexOf('/');
+        if (slash < 0) { ip = token; return 32; }
+        ip = token.Substring(0, slash);
+        return int.TryParse(token.Substring(slash + 1), out var p) && p >= 0 && p <= 32 ? p : 32;
+    }
+
+    public static bool? InRange(string ip, string cidr)
+    {
+        if (string.IsNullOrEmpty(ip) || string.IsNullOrEmpty(cidr)) return null;
+        var slash = cidr.IndexOf('/');
+        if (slash < 0) return null;
+        if (!TryParse(ip, out var ipv) || !TryParse(cidr.Substring(0, slash), out var basev)) return null;
+        if (!int.TryParse(cidr.Substring(slash + 1), out var bits) || bits < 0 || bits > 32) return null;
+        var mask = bits == 0 ? 0u : 0xFFFFFFFFu << (32 - bits);
+        return (ipv & mask) == (basev & mask);
+    }
+
+    public static bool? MaskedEqual(string a, string b, long? prefixArg)
+    {
+        var m = Masked(a, b, prefixArg, out var av, out var bv);
+        return m is null ? null : av == bv;
+    }
+
+    public static long? MaskedCompare(string a, string b, long? prefixArg)
+    {
+        var m = Masked(a, b, prefixArg, out var av, out var bv);
+        return m is null ? null : (av == bv ? 0L : av < bv ? -1L : 1L);
+    }
+
+    // Parse both operands (each may carry its own /prefix), mask to the smallest of the two suffixes and any explicit
+    // prefix argument, and hand back the masked values. Null when either operand is unparseable.
+    private static bool? Masked(string a, string b, long? prefixArg, out uint av, out uint bv)
+    {
+        av = 0; bv = 0;
+        if (string.IsNullOrEmpty(a) || string.IsNullOrEmpty(b)) return null;
+        var pa = SplitPrefix(a, out var aIp);
+        var pb = SplitPrefix(b, out var bIp);
+        if (!TryParse(aIp, out var a0) || !TryParse(bIp, out var b0)) return null;
+        var bits = Math.Min(Math.Min(pa, pb), (int)(prefixArg ?? 32));
+        if (bits < 0 || bits > 32) return null;
+        var mask = bits == 0 ? 0u : 0xFFFFFFFFu << (32 - bits);
+        av = a0 & mask; bv = b0 & mask;
+        return true;
+    }
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4Support.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4Support.cs
@@ -37,6 +37,54 @@ internal static class Ipv4Support
         return (ipv & mask) == (basev & mask);
     }
 
+    public static string UintToDotted(uint v) =>
+        $"{(v >> 24) & 0xFF}.{(v >> 16) & 0xFF}.{(v >> 8) & 0xFF}.{v & 0xFF}";
+
+    // The network address of 'ip' masked to the smaller of its own /suffix and 'prefix' (default 32), as a uint.
+    // Null when the address is unparseable or the effective prefix is out of range.
+    public static uint? MaskedValue(string ip, long? prefix)
+    {
+        if (string.IsNullOrEmpty(ip)) return null;
+        var p = SplitPrefix(ip, out var addr);
+        if (!TryParse(addr, out var v)) return null;
+        var bits = (int)System.Math.Min(p, prefix ?? 32);
+        if (bits < 0 || bits > 32) return null;
+        var mask = bits == 0 ? 0u : 0xFFFFFFFFu << (32 - bits);
+        return v & mask;
+    }
+
+    // format_ipv4: the masked network address as dotted-quad.
+    public static string? FormatV4(string ip, long? prefix)
+    {
+        var v = MaskedValue(ip, prefix);
+        return v is null ? null : UintToDotted(v.Value);
+    }
+
+    // format_ipv4_mask: the masked network address in CIDR notation, using the effective prefix.
+    public static string? FormatV4Mask(string ip, long prefix)
+    {
+        if (prefix < 0 || prefix > 32) return null;
+        var p = SplitPrefix(ip, out _);
+        var bits = System.Math.Min(p, (int)prefix);
+        var v = MaskedValue(ip, prefix);
+        return v is null ? null : $"{UintToDotted(v.Value)}/{bits}";
+    }
+
+    // ipv4_netmask_suffix: the /suffix of a CIDR (32 when none present); null when the address is unparseable.
+    public static long? NetmaskSuffix(string ipRange)
+    {
+        if (string.IsNullOrEmpty(ipRange)) return null;
+        var p = SplitPrefix(ipRange, out var addr);
+        return TryParse(addr, out _) ? p : null;
+    }
+
+    // parse_ipv4_mask: the masked network address as a long.
+    public static long? ParseV4Mask(string ip, long prefix)
+    {
+        var v = MaskedValue(ip, prefix);
+        return v is null ? null : (long)v.Value;
+    }
+
     public static bool? MaskedEqual(string a, string b, long? prefixArg)
     {
         var m = Masked(a, b, prefixArg, out var av, out var bv);

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/ParseIpv4MaskFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/ParseIpv4MaskFunction.cs
@@ -1,0 +1,9 @@
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// parse_ipv4_mask(ip, prefix) -> the network address masked to the effective prefix as a long; null when the address is
+// unparseable or the prefix is out of range.
+[KustoImplementation(Keyword = "Functions.ParseIPV4Mask")]
+internal partial class ParseIpv4MaskFunction
+{
+    private static long? Impl(string ip, long prefix) => Ipv4Support.ParseV4Mask(ip, prefix);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/ParseUrlFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/ParseUrlFunction.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// parse_url(url) -> a dynamic object with the URL's Scheme, Host, Port, Path, Username, Password, Query Parameters and
+// Fragment components (empty strings / an empty object for absent parts), matching ADX.
+[KustoImplementation(Keyword = "Functions.ParseUrl")]
+internal partial class ParseUrlFunction
+{
+    private static JsonNode? Impl(string url) => UrlSupport.ParseUrl(url);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/ParseUrlQueryFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/ParseUrlQueryFunction.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// parse_urlquery(query) -> a dynamic object { "Query Parameters": { key: value, ... } } from a URL query string.
+[KustoImplementation(Keyword = "Functions.ParseUrlQuery")]
+internal partial class ParseUrlQueryFunction
+{
+    private static JsonNode? Impl(string query) => new JsonObject { ["Query Parameters"] = UrlSupport.ParseQuery(query) };
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/ParseUserAgentFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/ParseUserAgentFunction.cs
@@ -1,0 +1,98 @@
+//
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using Kusto.Language;
+using Kusto.Language.Symbols;
+using KustoLoco.Core.DataSource;
+using KustoLoco.Core.DataSource.Columns;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// parse_user_agent(user_agent, look_for) -> dynamic with the requested component(s): "browser" -> { Browser: {...} },
+// "os" -> { OperatingSystem: {...} }, "device" -> { Device: {...} }. look_for is one of those strings or a dynamic
+// array of them. Backed by the host-registered IUserAgentParser (via EvaluationContext.Providers); the engine ships no
+// user-agent database. No parser or a null user agent yields null.
+internal class ParseUserAgentFunctionImpl : IScalarFunctionImpl, IContextualScalarFunctionImpl
+{
+    public ScalarResult InvokeScalar(ScalarResult[] arguments) => InvokeScalar(arguments, default);
+
+    public ColumnarResult InvokeColumnar(ColumnarResult[] arguments) => InvokeColumnar(arguments, default);
+
+    public ScalarResult InvokeScalar(ScalarResult[] arguments, EvaluationContext context)
+    {
+        var parser = context.Providers?.Get<IUserAgentParser>();
+        return new ScalarResult(ScalarTypes.Dynamic,
+            Parse(parser, arguments[0].Value as string, arguments[1].Value));
+    }
+
+    public ColumnarResult InvokeColumnar(ColumnarResult[] arguments, EvaluationContext context)
+    {
+        var parser = context.Providers?.Get<IUserAgentParser>();
+        var rowCount = arguments[0].Column.RowCount;
+        var data = NullableSetBuilderOfJsonNode.CreateFixed(rowCount);
+        for (var row = 0; row < rowCount; row++)
+            data[row] = Parse(parser, arguments[0].Column.GetRawDataValue(row) as string,
+                arguments[1].Column.GetRawDataValue(row));
+        return new ColumnarResult(GenericColumnFactoryOfJsonNode.CreateFromDataSet(data.ToNullableSet()));
+    }
+
+    private static JsonNode? Parse(IUserAgentParser? parser, string? ua, object? lookFor)
+    {
+        if (parser is null || ua is null) return null;
+        var info = parser.Parse(ua);
+        var wanted = LookForSet(lookFor);
+        var obj = new JsonObject();
+        if (wanted.Contains("browser")) obj["Browser"] = Software(info.Browser, includePatchMinor: false);
+        if (wanted.Contains("os")) obj["OperatingSystem"] = Software(info.OperatingSystem, includePatchMinor: true);
+        if (wanted.Contains("device")) obj["Device"] = Device(info.Device);
+        return obj;
+    }
+
+    private static HashSet<string> LookForSet(object? lookFor)
+    {
+        var set = new HashSet<string>();
+        void Add(string? s) { if (!string.IsNullOrEmpty(s)) set.Add(Normalize(s)); }
+        switch (lookFor)
+        {
+            case string s: Add(s); break;
+            case JsonArray arr:
+                foreach (var el in arr) Add(el?.ToString());
+                break;
+            case JsonValue v when v.TryGetValue<string>(out var vs): Add(vs); break;
+        }
+        return set;
+    }
+
+    private static string Normalize(string s) => s.Trim().ToLowerInvariant() switch
+    {
+        "os" or "operatingsystem" or "operating_system" => "os",
+        _ => s.Trim().ToLowerInvariant()
+    };
+
+    private static JsonObject Software(UserAgentSoftware s, bool includePatchMinor)
+    {
+        var o = new JsonObject
+        {
+            ["Family"] = s.Family,
+            ["Major"] = s.Major,
+            ["Minor"] = s.Minor,
+            ["Patch"] = s.Patch,
+        };
+        if (includePatchMinor) o["PatchMinor"] = s.PatchMinor;
+        return o;
+    }
+
+    private static JsonObject Device(UserAgentDevice d) => new()
+    {
+        ["Family"] = d.Family,
+        ["Brand"] = d.Brand,
+        ["Model"] = d.Model,
+    };
+
+    internal static void Register(Dictionary<FunctionSymbol, ScalarFunctionInfo> functions) =>
+        functions.Add(Functions.ParseUserAgent, new ScalarFunctionInfo(
+            new ScalarOverloadInfo(new ParseUserAgentFunctionImpl(), ScalarTypes.Dynamic, ScalarTypes.String, ScalarTypes.String),
+            new ScalarOverloadInfo(new ParseUserAgentFunctionImpl(), ScalarTypes.Dynamic, ScalarTypes.String, ScalarTypes.Dynamic)));
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/SetHasElementFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/SetHasElementFunction.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// set_has_element(set, value) -> true iff the dynamic array 'set' contains 'value' (by JSON value-equality); null when
+// 'set' is not a dynamic array. The value argument is polymorphic in ADX, so one overload per scalar type (the source
+// generator names each distinctly-suffixed *Impl method as its own overload).
+[KustoImplementation(Keyword = "Functions.SetHasElement")]
+internal partial class SetHasElementFunction
+{
+    private static bool? StringImpl(JsonNode set, string value) => DynamicSetSupport.Has(set, JsonValue.Create(value));
+    private static bool? LongImpl(JsonNode set, long value) => DynamicSetSupport.Has(set, JsonValue.Create(value));
+    private static bool? RealImpl(JsonNode set, double value) => DynamicSetSupport.Has(set, JsonValue.Create(value));
+    private static bool? BoolImpl(JsonNode set, bool value) => DynamicSetSupport.Has(set, JsonValue.Create(value));
+    private static bool? Impl(JsonNode set, JsonNode value) => DynamicSetSupport.Has(set, value);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/SetOperationFunctions.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/SetOperationFunctions.cs
@@ -1,0 +1,126 @@
+//
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+using Kusto.Language;
+using Kusto.Language.Symbols;
+using KustoLoco.Core.DataSource;
+using KustoLoco.Core.DataSource.Columns;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// set_union / set_intersect / set_difference take an arbitrary number of dynamic arrays, so they are registered
+// manually (one overload per argument count) rather than via the source generator. All three deduplicate by JSON
+// value-equality (canonical JSON text) and preserve first-occurrence order, matching ADX.
+internal static class SetOpsSupport
+{
+    private const int MinSets = 2;
+    private const int MaxSets = 64;
+
+    private static IEnumerable<JsonNode?> Elements(object? value) =>
+        value is JsonArray a ? a : Enumerable.Empty<JsonNode?>();
+
+    private static string Key(JsonNode? node) => node?.ToJsonString() ?? "null";
+
+    public static JsonNode Union(IReadOnlyList<object?> values)
+    {
+        var seen = new HashSet<string>();
+        var result = new JsonArray();
+        foreach (var v in values)
+            foreach (var el in Elements(v))
+                if (seen.Add(Key(el)))
+                    result.Add(el?.DeepClone());
+        return result;
+    }
+
+    public static JsonNode Intersect(IReadOnlyList<object?> values)
+    {
+        var others = new List<HashSet<string>>();
+        for (var i = 1; i < values.Count; i++)
+            others.Add(Elements(values[i]).Select(Key).ToHashSet());
+        var seen = new HashSet<string>();
+        var result = new JsonArray();
+        foreach (var el in Elements(values.Count > 0 ? values[0] : null))
+        {
+            var key = Key(el);
+            if (!seen.Add(key)) continue;
+            if (others.All(s => s.Contains(key))) result.Add(el?.DeepClone());
+        }
+        return result;
+    }
+
+    public static JsonNode Difference(IReadOnlyList<object?> values)
+    {
+        var exclude = new HashSet<string>();
+        for (var i = 1; i < values.Count; i++)
+            foreach (var el in Elements(values[i]))
+                exclude.Add(Key(el));
+        var seen = new HashSet<string>();
+        var result = new JsonArray();
+        foreach (var el in Elements(values.Count > 0 ? values[0] : null))
+        {
+            var key = Key(el);
+            if (!seen.Add(key)) continue;
+            if (!exclude.Contains(key)) result.Add(el?.DeepClone());
+        }
+        return result;
+    }
+
+    public static void Register(Dictionary<FunctionSymbol, ScalarFunctionInfo> functions,
+        FunctionSymbol symbol, IScalarFunctionImpl impl)
+    {
+        var overloads = Enumerable.Range(MinSets, MaxSets - MinSets + 1)
+            .Select(n => new ScalarOverloadInfo(impl, ScalarTypes.Dynamic,
+                Enumerable.Repeat(ScalarTypes.Dynamic, n).ToArray()))
+            .ToArray();
+        functions.Add(symbol, new ScalarFunctionInfo(overloads));
+    }
+}
+
+internal class SetUnionFunctionImpl : IScalarFunctionImpl
+{
+    public ScalarResult InvokeScalar(ScalarResult[] arguments) =>
+        new(ScalarTypes.Dynamic, SetOpsSupport.Union(arguments.Select(a => a.Value).ToArray()));
+
+    public ColumnarResult InvokeColumnar(ColumnarResult[] arguments) => SetColumnar.Apply(arguments, SetOpsSupport.Union);
+
+    internal static void Register(Dictionary<FunctionSymbol, ScalarFunctionInfo> f) =>
+        SetOpsSupport.Register(f, Functions.SetUnion, new SetUnionFunctionImpl());
+}
+
+internal class SetIntersectFunctionImpl : IScalarFunctionImpl
+{
+    public ScalarResult InvokeScalar(ScalarResult[] arguments) =>
+        new(ScalarTypes.Dynamic, SetOpsSupport.Intersect(arguments.Select(a => a.Value).ToArray()));
+
+    public ColumnarResult InvokeColumnar(ColumnarResult[] arguments) => SetColumnar.Apply(arguments, SetOpsSupport.Intersect);
+
+    internal static void Register(Dictionary<FunctionSymbol, ScalarFunctionInfo> f) =>
+        SetOpsSupport.Register(f, Functions.SetIntersect, new SetIntersectFunctionImpl());
+}
+
+internal class SetDifferenceFunctionImpl : IScalarFunctionImpl
+{
+    public ScalarResult InvokeScalar(ScalarResult[] arguments) =>
+        new(ScalarTypes.Dynamic, SetOpsSupport.Difference(arguments.Select(a => a.Value).ToArray()));
+
+    public ColumnarResult InvokeColumnar(ColumnarResult[] arguments) => SetColumnar.Apply(arguments, SetOpsSupport.Difference);
+
+    internal static void Register(Dictionary<FunctionSymbol, ScalarFunctionInfo> f) =>
+        SetOpsSupport.Register(f, Functions.SetDifference, new SetDifferenceFunctionImpl());
+}
+
+internal static class SetColumnar
+{
+    public static ColumnarResult Apply(ColumnarResult[] arguments,
+        System.Func<IReadOnlyList<object?>, JsonNode> op)
+    {
+        var rowCount = arguments[0].Column.RowCount;
+        var data = NullableSetBuilderOfJsonNode.CreateFixed(rowCount);
+        for (var row = 0; row < rowCount; row++)
+            data[row] = op(arguments.Select(a => a.Column.GetRawDataValue(row)).ToArray());
+        return new ColumnarResult(GenericColumnFactoryOfJsonNode.CreateFromDataSet(data.ToNullableSet()));
+    }
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/UrlSupport.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/UrlSupport.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// Shared helpers for parse_url / parse_urlquery. Parsed literally (not via System.Uri, which would fill in default
+// ports and normalise the path) to match ADX's component breakdown.
+internal static class UrlSupport
+{
+    public static JsonNode ParseUrl(string? url)
+    {
+        var scheme = "";
+        var host = "";
+        var port = "";
+        var path = "";
+        var username = "";
+        var password = "";
+        var fragment = "";
+        var query = "";
+        var rest = url ?? "";
+
+        var schemeIdx = rest.IndexOf("://", StringComparison.Ordinal);
+        if (schemeIdx >= 0) { scheme = rest.Substring(0, schemeIdx); rest = rest.Substring(schemeIdx + 3); }
+
+        var hashIdx = rest.IndexOf('#');
+        if (hashIdx >= 0) { fragment = rest.Substring(hashIdx + 1); rest = rest.Substring(0, hashIdx); }
+
+        var qIdx = rest.IndexOf('?');
+        if (qIdx >= 0) { query = rest.Substring(qIdx + 1); rest = rest.Substring(0, qIdx); }
+
+        var slashIdx = rest.IndexOf('/');
+        var authority = rest;
+        if (slashIdx >= 0) { path = rest.Substring(slashIdx); authority = rest.Substring(0, slashIdx); }
+
+        var atIdx = authority.IndexOf('@');
+        if (atIdx >= 0)
+        {
+            var userinfo = authority.Substring(0, atIdx);
+            authority = authority.Substring(atIdx + 1);
+            var colon = userinfo.IndexOf(':');
+            if (colon >= 0) { username = userinfo.Substring(0, colon); password = userinfo.Substring(colon + 1); }
+            else username = userinfo;
+        }
+
+        var portColon = authority.LastIndexOf(':');
+        if (portColon >= 0) { host = authority.Substring(0, portColon); port = authority.Substring(portColon + 1); }
+        else host = authority;
+
+        return new JsonObject
+        {
+            ["Scheme"] = scheme,
+            ["Host"] = host,
+            ["Port"] = port,
+            ["Path"] = path,
+            ["Username"] = username,
+            ["Password"] = password,
+            ["Query Parameters"] = ParseQuery(query),
+            ["Fragment"] = fragment,
+        };
+    }
+
+    public static JsonObject ParseQuery(string? query)
+    {
+        var qp = new JsonObject();
+        if (string.IsNullOrEmpty(query)) return qp;
+        // a full URL or leading '?' is tolerated: keep only the query segment.
+        var q = query;
+        var qIdx = q.IndexOf('?');
+        if (qIdx >= 0) q = q.Substring(qIdx + 1);
+        var hashIdx = q.IndexOf('#');
+        if (hashIdx >= 0) q = q.Substring(0, hashIdx);
+        foreach (var pair in q.Split('&'))
+        {
+            if (pair.Length == 0) continue;
+            var eq = pair.IndexOf('=');
+            if (eq >= 0) qp[pair.Substring(0, eq)] = pair.Substring(eq + 1);
+            else qp[pair] = "";
+        }
+        return qp;
+    }
+}

--- a/libraries/KustoLoco.Core/Evaluation/Infra/EvaluationContext.cs
+++ b/libraries/KustoLoco.Core/Evaluation/Infra/EvaluationContext.cs
@@ -29,4 +29,8 @@ internal readonly record struct EvaluationContext
     public ITableChunk Chunk { get; init; }
 
     public TabularResult Left { get; init; }
+
+    // Host-registered providers for data-backed scalar functions, threaded from the engine. Null when none are
+    // registered; functions treat that as "no data" and return null.
+    public IProviderRegistry? Providers { get; init; }
 }

--- a/libraries/KustoLoco.Core/Evaluation/Providers/Providers.cs
+++ b/libraries/KustoLoco.Core/Evaluation/Providers/Providers.cs
@@ -42,3 +42,27 @@ public sealed record GeoIpInfo(
     string? City = null,
     double? Latitude = null,
     double? Longitude = null);
+
+// parse_user_agent data provider. The engine ships no user-agent database; a faithful implementation (e.g. one backed
+// by the uap-core dataset) lives in a companion package and is registered by the host.
+public interface IUserAgentParser
+{
+    UserAgentInfo Parse(string userAgent);
+}
+
+public sealed record UserAgentInfo(
+    UserAgentSoftware Browser,
+    UserAgentSoftware OperatingSystem,
+    UserAgentDevice Device);
+
+public sealed record UserAgentSoftware(
+    string? Family = null,
+    string? Major = null,
+    string? Minor = null,
+    string? Patch = null,
+    string? PatchMinor = null);
+
+public sealed record UserAgentDevice(
+    string? Family = null,
+    string? Brand = null,
+    string? Model = null);

--- a/libraries/KustoLoco.Core/Evaluation/Providers/Providers.cs
+++ b/libraries/KustoLoco.Core/Evaluation/Providers/Providers.cs
@@ -1,0 +1,44 @@
+//
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+
+namespace KustoLoco.Core;
+
+// A per-query registry of host-supplied providers that data-backed scalar functions read at evaluation time. It is
+// registered on the engine and threaded through the EvaluationContext. When a function's provider is absent the
+// function returns null (inert) rather than failing, so queries that reference it still run.
+public interface IProviderRegistry
+{
+    T? Get<T>() where T : class;
+}
+
+public sealed class ProviderRegistry : IProviderRegistry
+{
+    private readonly Dictionary<Type, object> _providers = new();
+
+    public ProviderRegistry Set<T>(T provider) where T : class
+    {
+        _providers[typeof(T)] = provider;
+        return this;
+    }
+
+    public T? Get<T>() where T : class =>
+        _providers.TryGetValue(typeof(T), out var p) ? (T)p : null;
+}
+
+// geo_info_from_ip_address data provider. The engine ships no geo database (licences vary and not every consumer wants
+// the dependency); the host supplies the IP -> geo lookup. Returning null for an address yields a null function result.
+public interface IGeoIpProvider
+{
+    GeoIpInfo? Lookup(IPAddress address);
+}
+
+public sealed record GeoIpInfo(
+    string? Country = null,
+    string? State = null,
+    string? City = null,
+    double? Latitude = null,
+    double? Longitude = null);

--- a/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.Expressions.FunctionCalls.cs
+++ b/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.Expressions.FunctionCalls.cs
@@ -56,7 +56,7 @@ internal partial class TreeEvaluator
             arguments = new[] { dummy }.Concat(arguments).ToArray();
         }
 
-        return impl(arguments);
+        return impl(arguments, context);
     }
 
     public override EvaluationResult VisitBuiltInWindowFunctionCall(IRBuiltInWindowFunctionCallNode node,
@@ -134,7 +134,7 @@ internal partial class TreeEvaluator
             functionCallScope.AddSymbol(node.ParamSymbols[i], argValue);
         }
 
-        return node.ExpandedBody.Accept(this, new EvaluationContext(functionCallScope));
+        return node.ExpandedBody.Accept(this, new EvaluationContext(functionCallScope) { Providers = context.Providers });
     }
 
     public override EvaluationResult VisitFunctionBody(IRFunctionBodyNode node, EvaluationContext context)

--- a/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.Expressions.Operators.cs
+++ b/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.Expressions.Operators.cs
@@ -17,7 +17,7 @@ internal partial class TreeEvaluator
 
         var val = node.Expression.Accept(this, context);
         var arguments = new[] { val };
-        return impl(arguments);
+        return impl(arguments, context);
     }
 
     public override EvaluationResult VisitBinaryExpression(IRBinaryExpressionNode node, EvaluationContext context)
@@ -34,6 +34,6 @@ internal partial class TreeEvaluator
         var leftVal = node.Left.Accept(this, context);
         var rightVal = node.Right.Accept(this, context);
         var arguments = new[] { leftVal, rightVal };
-        return impl(arguments);
+        return impl(arguments, context);
     }
 }

--- a/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.Join.cs
+++ b/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.Join.cs
@@ -51,7 +51,7 @@ internal partial class TreeEvaluator
 
         public IEnumerable<ITableChunk> GetData()
         {
-            var rightContext = new EvaluationContext(_context.Scope);
+            var rightContext = new EvaluationContext(_context.Scope) { Providers = _context.Providers };
             var rightResult = _rightExpression.Accept(_owner, rightContext);
             if (rightResult == EvaluationResult.Null || !rightResult.IsTabular)
                 throw new InvalidOperationException(
@@ -83,7 +83,7 @@ internal partial class TreeEvaluator
 
             var onValuesColumns = new List<BaseColumn>(_onClauses.Count);
 
-            var chunkContext = new EvaluationContext(_context.Scope, chunk);
+            var chunkContext = new EvaluationContext(_context.Scope, chunk) { Providers = _context.Providers };
             foreach (var onExpression in onExpressions)
             {
                 var onExpressionResult = (ColumnarResult?)onExpression.Accept(_owner, chunkContext);

--- a/libraries/KustoLoco.Core/KustoQueryContext.cs
+++ b/libraries/KustoLoco.Core/KustoQueryContext.cs
@@ -34,6 +34,7 @@ public class KustoQueryContext
 {
     
     private Dictionary<FunctionSymbol, ScalarFunctionInfo> _additionalFunctions = [];
+    private readonly ProviderRegistry _providers = new();
     private IKustoConsole _debugConsole = new SystemConsole();
 
     private IKustoQueryContextTableLoader _lazyTableLoader = new NullTableLoader();
@@ -162,11 +163,22 @@ public class KustoQueryContext
     }
 
     /// <summary>
+    ///     Registers a host-supplied provider (for example an IGeoIpProvider) that context-aware scalar functions read
+    ///     at evaluation time. Absent providers leave their functions returning null.
+    /// </summary>
+    public KustoQueryContext AddProvider<T>(T provider) where T : class
+    {
+        _providers.Set(provider);
+        return this;
+    }
+
+    /// <summary>
     ///     Runs a query and evaluates the result in order to get an accurate benchmark
     /// </summary>
     public int BenchmarkQuery(string query)
     {
         var engine = new BabyKustoEngine(new SystemConsole(),_settings);
+        engine.UseProviders(_providers);
         var res = engine.Evaluate(_tables, query);
         return res.RowCount;
     }
@@ -183,6 +195,7 @@ public class KustoQueryContext
         var watch = Stopwatch.StartNew();
         var engine = new BabyKustoEngine(_debugConsole,_settings);
         engine.AddAdditionalFunctions(_additionalFunctions);
+        engine.UseProviders(_providers);
         //handling for "special" commands
         if (query.Trim() == ".tables")
             return CreateTableList(query, false);

--- a/test/BasicTests/BagFunctionTests.cs
+++ b/test/BasicTests/BagFunctionTests.cs
@@ -1,0 +1,40 @@
+using AwesomeAssertions;
+
+namespace BasicTests;
+
+[TestClass]
+public class BagFunctionTests : TestMethods
+{
+    [TestMethod]
+    public async Task BagHasKey_Present() =>
+        (await LastLineOfResult("print bag_has_key(dynamic({\"a\":1,\"b\":2}), 'a')")).Should().Be("True");
+
+    [TestMethod]
+    public async Task BagHasKey_Absent() =>
+        (await LastLineOfResult("print bag_has_key(dynamic({\"a\":1,\"b\":2}), 'z')")).Should().Be("False");
+
+    [TestMethod]
+    public async Task BagRemoveKeys() =>
+        (await SquashedLastLineOfResult("print bag_remove_keys(dynamic({\"a\":1,\"b\":2,\"c\":3}), dynamic([\"a\",\"c\"]))"))
+            .Should().Be("{\"b\":2}");
+
+    [TestMethod]
+    public async Task BagSetKey_AddNew() =>
+        (await SquashedLastLineOfResult("print bag_set_key(dynamic({\"a\":1}), 'b', 2)"))
+            .Should().Be("{\"a\":1,\"b\":2}");
+
+    [TestMethod]
+    public async Task BagSetKey_Overwrite() =>
+        (await SquashedLastLineOfResult("print bag_set_key(dynamic({\"a\":1}), 'a', 5)"))
+            .Should().Be("{\"a\":5}");
+
+    [TestMethod]
+    public async Task BagSetKey_StringValue() =>
+        (await SquashedLastLineOfResult("print bag_set_key(dynamic({\"a\":1}), 'b', 'x')"))
+            .Should().Be("{\"a\":1,\"b\":\"x\"}");
+
+    [TestMethod]
+    public async Task BagZip() =>
+        (await SquashedLastLineOfResult("print bag_zip(dynamic([\"a\",\"b\",\"c\"]), dynamic([1,2,3]))"))
+            .Should().Be("{\"a\":1,\"b\":2,\"c\":3}");
+}

--- a/test/BasicTests/DynamicSetFunctionTests.cs
+++ b/test/BasicTests/DynamicSetFunctionTests.cs
@@ -1,0 +1,64 @@
+using AwesomeAssertions;
+
+namespace BasicTests;
+
+[TestClass]
+public class DynamicSetFunctionTests : TestMethods
+{
+    [TestMethod]
+    public async Task SetHasElement_Present()
+    {
+        var query = "print set_has_element(dynamic([1,2,3]), 2)";
+        var result = await LastLineOfResult(query);
+        result.Should().Be("True");
+    }
+
+    [TestMethod]
+    public async Task SetHasElement_Absent()
+    {
+        var query = "print set_has_element(dynamic([1,2,3]), 5)";
+        var result = await LastLineOfResult(query);
+        result.Should().Be("False");
+    }
+
+    [TestMethod]
+    public async Task SetHasElement_String()
+    {
+        var query = "print set_has_element(dynamic([\"a\",\"b\",\"c\"]), \"b\")";
+        var result = await LastLineOfResult(query);
+        result.Should().Be("True");
+    }
+
+    [TestMethod]
+    public async Task SetHasElement_StringAbsent()
+    {
+        var query = "print set_has_element(dynamic([\"a\",\"b\",\"c\"]), \"z\")";
+        var result = await LastLineOfResult(query);
+        result.Should().Be("False");
+    }
+
+    [TestMethod]
+    public async Task SetHasElement_NotAnArray_IsNull()
+    {
+        // set_has_element over a non-array dynamic yields null (renders as empty).
+        var query = "print set_has_element(dynamic({\"a\":1}), 1)";
+        var result = await LastLineOfResult(query);
+        result.Should().Be("");
+    }
+
+    [TestMethod]
+    public async Task BagKeys_Object()
+    {
+        var query = "print tostring(bag_keys(dynamic({\"a\":1,\"b\":2,\"c\":3})))";
+        var result = await LastLineOfResult(query);
+        result.Should().Be("[\"a\",\"b\",\"c\"]");
+    }
+
+    [TestMethod]
+    public async Task BagKeys_NotAnObject_IsNull()
+    {
+        var query = "print bag_keys(dynamic([1,2,3]))";
+        var result = await LastLineOfResult(query);
+        result.Should().Be("");
+    }
+}

--- a/test/BasicTests/ExtractAllFunctionTests.cs
+++ b/test/BasicTests/ExtractAllFunctionTests.cs
@@ -1,0 +1,31 @@
+using AwesomeAssertions;
+
+namespace BasicTests;
+
+[TestClass]
+public class ExtractAllFunctionTests : TestMethods
+{
+    [TestMethod]
+    public async Task ExtractAll_NoGroups_FullMatches()
+    {
+        var query = "print tostring(extract_all(@'\\d+', 'a1b22c333'))";
+        var result = await LastLineOfResult(query);
+        result.Should().Be("[\"1\",\"22\",\"333\"]");
+    }
+
+    [TestMethod]
+    public async Task ExtractAll_OneGroup()
+    {
+        var query = "print tostring(extract_all(@'(\\d)\\d', '12 34 56'))";
+        var result = await LastLineOfResult(query);
+        result.Should().Be("[\"1\",\"3\",\"5\"]");
+    }
+
+    [TestMethod]
+    public async Task ExtractAll_NoMatch_EmptyArray()
+    {
+        var query = "print tostring(extract_all(@'\\d+', 'abc'))";
+        var result = await LastLineOfResult(query);
+        result.Should().Be("[]");
+    }
+}

--- a/test/BasicTests/GeoInfoFromIpFunctionTests.cs
+++ b/test/BasicTests/GeoInfoFromIpFunctionTests.cs
@@ -1,0 +1,50 @@
+using System.Linq;
+using System.Net;
+using AwesomeAssertions;
+using KustoLoco.Core;
+using NotNullStrings;
+
+namespace BasicTests;
+
+[TestClass]
+public class GeoInfoFromIpFunctionTests : TestMethods
+{
+    private sealed class StubGeoProvider : IGeoIpProvider
+    {
+        public GeoIpInfo? Lookup(IPAddress address) =>
+            address.ToString() == "8.8.8.8"
+                ? new GeoIpInfo("United States", "California", "Mountain View", 37.386, -122.0838)
+                : null;
+    }
+
+    private static string LastLine(KustoQueryResult result) =>
+        result.GetRow(result.RowCount - 1).Select(KustoFormatter.ObjectToKustoString).JoinString();
+
+    [TestMethod]
+    public async Task GeoInfoFromIp_WithProvider_Resolves()
+    {
+        var context = CreateContext();
+        context.AddProvider<IGeoIpProvider>(new StubGeoProvider());
+        var result = await context.RunQuery("print tostring(geo_info_from_ip_address('8.8.8.8'))");
+        var line = LastLine(result);
+        line.Should().Contain("United States");
+        line.Should().Contain("Mountain View");
+    }
+
+    [TestMethod]
+    public async Task GeoInfoFromIp_UnknownAddress_Null()
+    {
+        var context = CreateContext();
+        context.AddProvider<IGeoIpProvider>(new StubGeoProvider());
+        var result = await context.RunQuery("print geo_info_from_ip_address('1.2.3.4')");
+        LastLine(result).Should().Be("<null>");
+    }
+
+    [TestMethod]
+    public async Task GeoInfoFromIp_NoProvider_InertNull()
+    {
+        var context = CreateContext();   // no provider registered -> function stays inert
+        var result = await context.RunQuery("print geo_info_from_ip_address('8.8.8.8')");
+        LastLine(result).Should().Be("<null>");
+    }
+}

--- a/test/BasicTests/Ipv4FormatFunctionTests.cs
+++ b/test/BasicTests/Ipv4FormatFunctionTests.cs
@@ -1,0 +1,35 @@
+using AwesomeAssertions;
+
+namespace BasicTests;
+
+[TestClass]
+public class Ipv4FormatFunctionTests : TestMethods
+{
+    [TestMethod]
+    public async Task FormatIpv4_NoPrefix() =>
+        (await LastLineOfResult("print format_ipv4('192.168.1.255')")).Should().Be("192.168.1.255");
+
+    [TestMethod]
+    public async Task FormatIpv4_Prefix() =>
+        (await LastLineOfResult("print format_ipv4('192.168.1.255', 24)")).Should().Be("192.168.1.0");
+
+    [TestMethod]
+    public async Task FormatIpv4_BadIp_Null() =>
+        (await LastLineOfResult("print format_ipv4('nope', 24)")).Should().Be("<null>");
+
+    [TestMethod]
+    public async Task FormatIpv4Mask() =>
+        (await LastLineOfResult("print format_ipv4_mask('192.168.1.255', 24)")).Should().Be("192.168.1.0/24");
+
+    [TestMethod]
+    public async Task Ipv4NetmaskSuffix_Present() =>
+        (await LastLineOfResult("print ipv4_netmask_suffix('192.168.1.1/24')")).Should().Be("24");
+
+    [TestMethod]
+    public async Task Ipv4NetmaskSuffix_Absent_Is32() =>
+        (await LastLineOfResult("print ipv4_netmask_suffix('192.168.1.1')")).Should().Be("32");
+
+    [TestMethod]
+    public async Task ParseIpv4Mask() =>
+        (await LastLineOfResult("print parse_ipv4_mask('192.168.1.255', 24)")).Should().Be("3232235776");
+}

--- a/test/BasicTests/Ipv4FunctionTests.cs
+++ b/test/BasicTests/Ipv4FunctionTests.cs
@@ -1,0 +1,51 @@
+using AwesomeAssertions;
+
+namespace BasicTests;
+
+[TestClass]
+public class Ipv4FunctionTests : TestMethods
+{
+    [TestMethod]
+    public async Task Ipv4IsInRange_In() =>
+        (await LastLineOfResult("print ipv4_is_in_range('192.168.1.6', '192.168.1.0/24')")).Should().Be("True");
+
+    [TestMethod]
+    public async Task Ipv4IsInRange_Out() =>
+        (await LastLineOfResult("print ipv4_is_in_range('192.168.2.6', '192.168.1.0/24')")).Should().Be("False");
+
+    [TestMethod]
+    public async Task Ipv4IsInRange_BadIp_Null() =>
+        (await LastLineOfResult("print ipv4_is_in_range('not-an-ip', '192.168.1.0/24')")).Should().Be("<null>");
+
+    [TestMethod]
+    public async Task Ipv4Compare_Equal() =>
+        (await LastLineOfResult("print ipv4_compare('192.168.1.1', '192.168.1.1')")).Should().Be("0");
+
+    [TestMethod]
+    public async Task Ipv4Compare_Less() =>
+        (await LastLineOfResult("print ipv4_compare('192.168.1.1', '192.168.1.2')")).Should().Be("-1");
+
+    [TestMethod]
+    public async Task Ipv4Compare_PrefixMasksDifference() =>
+        (await LastLineOfResult("print ipv4_compare('192.168.1.1', '192.168.1.2', 24)")).Should().Be("0");
+
+    [TestMethod]
+    public async Task Ipv4IsMatch_SamePrefix() =>
+        (await LastLineOfResult("print ipv4_is_match('192.168.1.1', '192.168.1.2', 24)")).Should().Be("True");
+
+    [TestMethod]
+    public async Task Ipv4IsMatch_DifferentPrefix() =>
+        (await LastLineOfResult("print ipv4_is_match('192.168.1.1', '192.168.2.1', 24)")).Should().Be("False");
+
+    [TestMethod]
+    public async Task Ipv4IsInAnyRange_MatchCidr() =>
+        (await LastLineOfResult("print ipv4_is_in_any_range('10.0.0.5', dynamic([\"192.168.0.0/16\",\"10.0.0.0/8\"]))")).Should().Be("True");
+
+    [TestMethod]
+    public async Task Ipv4IsInAnyRange_MatchBareAddress() =>
+        (await LastLineOfResult("print ipv4_is_in_any_range('192.168.1.6', dynamic([\"192.168.1.6\",\"10.0.0.0/8\"]))")).Should().Be("True");
+
+    [TestMethod]
+    public async Task Ipv4IsInAnyRange_NoMatch() =>
+        (await LastLineOfResult("print ipv4_is_in_any_range('172.16.0.1', dynamic([\"192.168.0.0/16\",\"10.0.0.0/8\"]))")).Should().Be("False");
+}

--- a/test/BasicTests/Ipv4RangeHasFunctionTests.cs
+++ b/test/BasicTests/Ipv4RangeHasFunctionTests.cs
@@ -1,0 +1,42 @@
+using AwesomeAssertions;
+
+namespace BasicTests;
+
+[TestClass]
+public class Ipv4RangeHasFunctionTests : TestMethods
+{
+    [TestMethod]
+    public async Task RangeToCidr_AlignedBlock() =>
+        (await SquashedLastLineOfResult("print ipv4_range_to_cidr_list('192.168.1.0', '192.168.1.255')"))
+            .Should().Be("[\"192.168.1.0/24\"]");
+
+    [TestMethod]
+    public async Task RangeToCidr_SmallBlock() =>
+        (await SquashedLastLineOfResult("print ipv4_range_to_cidr_list('10.0.0.0', '10.0.0.3')"))
+            .Should().Be("[\"10.0.0.0/30\"]");
+
+    [TestMethod]
+    public async Task RangeToCidr_UnalignedSplit() =>
+        (await SquashedLastLineOfResult("print ipv4_range_to_cidr_list('10.0.0.1', '10.0.0.2')"))
+            .Should().Be("[\"10.0.0.1/32\",\"10.0.0.2/32\"]");
+
+    [TestMethod]
+    public async Task HasIpv4_Delimited() =>
+        (await LastLineOfResult("print has_ipv4('Source address 10.1.2.3 flagged', '10.1.2.3')")).Should().Be("True");
+
+    [TestMethod]
+    public async Task HasIpv4_NotDelimited_False() =>
+        (await LastLineOfResult("print has_ipv4('address 110.1.2.3 here', '10.1.2.3')")).Should().Be("False");
+
+    [TestMethod]
+    public async Task HasIpv4Prefix() =>
+        (await LastLineOfResult("print has_ipv4_prefix('conn to 10.1.2.3 open', '10.1.')")).Should().Be("True");
+
+    [TestMethod]
+    public async Task HasAnyIpv4_Match() =>
+        (await LastLineOfResult("print has_any_ipv4('hit 10.0.0.5 now', dynamic([\"192.168.0.1\",\"10.0.0.5\"]))")).Should().Be("True");
+
+    [TestMethod]
+    public async Task HasAnyIpv4Prefix_Match() =>
+        (await LastLineOfResult("print has_any_ipv4_prefix('hit 10.0.0.5 now', dynamic([\"192.168.\",\"10.0.\"]))")).Should().Be("True");
+}

--- a/test/BasicTests/ParseUserAgentFunctionTests.cs
+++ b/test/BasicTests/ParseUserAgentFunctionTests.cs
@@ -1,0 +1,51 @@
+using System.Linq;
+using AwesomeAssertions;
+using KustoLoco.Core;
+using NotNullStrings;
+
+namespace BasicTests;
+
+[TestClass]
+public class ParseUserAgentFunctionTests : TestMethods
+{
+    private sealed class StubUaParser : IUserAgentParser
+    {
+        public UserAgentInfo Parse(string userAgent) => new(
+            Browser: new UserAgentSoftware("Chrome", "120", "0", "0"),
+            OperatingSystem: new UserAgentSoftware("Windows", "10", null, null, null),
+            Device: new UserAgentDevice("Other"));
+    }
+
+    private static string LastLine(KustoQueryResult result) =>
+        result.GetRow(result.RowCount - 1).Select(KustoFormatter.ObjectToKustoString).JoinString();
+
+    [TestMethod]
+    public async Task ParseUserAgent_Browser()
+    {
+        var context = CreateContext();
+        context.AddProvider<IUserAgentParser>(new StubUaParser());
+        var result = await context.RunQuery("print tostring(parse_user_agent('ua-string', 'browser'))");
+        var line = LastLine(result);
+        line.Should().Contain("Chrome");
+        line.Should().Contain("Browser");
+    }
+
+    [TestMethod]
+    public async Task ParseUserAgent_BrowserAndOs()
+    {
+        var context = CreateContext();
+        context.AddProvider<IUserAgentParser>(new StubUaParser());
+        var result = await context.RunQuery("print tostring(parse_user_agent('ua-string', dynamic([\"browser\",\"os\"])))");
+        var line = LastLine(result);
+        line.Should().Contain("Chrome");
+        line.Should().Contain("Windows");
+    }
+
+    [TestMethod]
+    public async Task ParseUserAgent_NoProvider_Null()
+    {
+        var context = CreateContext();
+        var result = await context.RunQuery("print parse_user_agent('ua-string', 'browser')");
+        LastLine(result).Should().Be("<null>");
+    }
+}

--- a/test/BasicTests/SetOperationFunctionTests.cs
+++ b/test/BasicTests/SetOperationFunctionTests.cs
@@ -1,0 +1,42 @@
+using AwesomeAssertions;
+
+namespace BasicTests;
+
+[TestClass]
+public class SetOperationFunctionTests : TestMethods
+{
+    [TestMethod]
+    public async Task SetUnion_TwoArrays() =>
+        (await SquashedLastLineOfResult("print set_union(dynamic([1,2,3]), dynamic([3,4,5]))"))
+            .Should().Be("[1,2,3,4,5]");
+
+    [TestMethod]
+    public async Task SetUnion_ThreeArrays_Dedup() =>
+        (await SquashedLastLineOfResult("print set_union(dynamic([1,2]), dynamic([2,3]), dynamic([3,4]))"))
+            .Should().Be("[1,2,3,4]");
+
+    [TestMethod]
+    public async Task SetIntersect_Common() =>
+        (await SquashedLastLineOfResult("print set_intersect(dynamic([1,2,3,4]), dynamic([2,3,5]))"))
+            .Should().Be("[2,3]");
+
+    [TestMethod]
+    public async Task SetIntersect_ThreeArrays() =>
+        (await SquashedLastLineOfResult("print set_intersect(dynamic([1,2,3]), dynamic([2,3,4]), dynamic([3,4,5]))"))
+            .Should().Be("[3]");
+
+    [TestMethod]
+    public async Task SetDifference_FirstMinusRest() =>
+        (await SquashedLastLineOfResult("print set_difference(dynamic([1,2,3,4]), dynamic([2,4]))"))
+            .Should().Be("[1,3]");
+
+    [TestMethod]
+    public async Task SetDifference_MultipleExcludes() =>
+        (await SquashedLastLineOfResult("print set_difference(dynamic([1,2,3,4,5]), dynamic([2]), dynamic([4]))"))
+            .Should().Be("[1,3,5]");
+
+    [TestMethod]
+    public async Task SetUnion_Strings() =>
+        (await SquashedLastLineOfResult("print set_union(dynamic([\"a\",\"b\"]), dynamic([\"b\",\"c\"]))"))
+            .Should().Be("[\"a\",\"b\",\"c\"]");
+}

--- a/test/BasicTests/UrlFunctionTests.cs
+++ b/test/BasicTests/UrlFunctionTests.cs
@@ -1,0 +1,28 @@
+using AwesomeAssertions;
+
+namespace BasicTests;
+
+[TestClass]
+public class UrlFunctionTests : TestMethods
+{
+    [TestMethod]
+    public async Task ParseUrl_FullUrl() =>
+        (await SquashedLastLineOfResult(
+            "print parse_url('scheme://username:password@host:1234/this/is/a/path?k1=v1&k2=v2#fragment')"))
+            .Should().Be(
+                "{\"Scheme\":\"scheme\",\"Host\":\"host\",\"Port\":\"1234\",\"Path\":\"/this/is/a/path\"," +
+                "\"Username\":\"username\",\"Password\":\"password\"," +
+                "\"QueryParameters\":{\"k1\":\"v1\",\"k2\":\"v2\"},\"Fragment\":\"fragment\"}");
+
+    [TestMethod]
+    public async Task ParseUrl_MinimalHostPath() =>
+        (await SquashedLastLineOfResult("print parse_url('https://contoso.com/a/b')"))
+            .Should().Be(
+                "{\"Scheme\":\"https\",\"Host\":\"contoso.com\",\"Port\":\"\",\"Path\":\"/a/b\"," +
+                "\"Username\":\"\",\"Password\":\"\",\"QueryParameters\":{},\"Fragment\":\"\"}");
+
+    [TestMethod]
+    public async Task ParseUrlQuery() =>
+        (await SquashedLastLineOfResult("print parse_urlquery('k1=v1&k2=v2&k3=v3')"))
+            .Should().Be("{\"QueryParameters\":{\"k1\":\"v1\",\"k2\":\"v2\",\"k3\":\"v3\"}}");
+}


### PR DESCRIPTION
Implements the plugin architecture suggested in #613 — a small provider seam so the engine can host data-backed scalar functions **without Core taking on any data dependency** ("not everybody will want to depend on these libraries").

> **Stacked on #645** — please merge that first. The net-new work here is the last two commits (the provider seam + the two data-backed functions); the earlier commits are #645 and will drop out of this diff once it lands.

### The seam
- `EvaluationContext.Providers` (an `IProviderRegistry`) is threaded through the evaluator. Existing scalar functions are untouched — a new `IContextualScalarFunctionImpl` sibling interface lets a function opt into receiving the context, and the invoke sites route to it only when implemented.
- Hosts register providers via `context.AddProvider<T>(...)` / `engine.AddProvider<T>(...)`.

### Functions (inert until a provider is registered)
- `geo_info_from_ip_address(ip)` → `{country, state, city, latitude, longitude}` via `IGeoIpProvider` (the ADX shape).
- `parse_user_agent(ua, look_for)` → `{Browser{…}, OperatingSystem{…}, Device{…}}` via `IUserAgentParser`.

With no provider registered, both return `null` (the query still runs), so Core stays dependency-free. Faithful data implementations ship as **optional companion packages** (a DB-IP–backed `KustoLoco.Geo` and a uap-core–backed `KustoLoco.UserAgent`) in a follow-up PR that builds on this seam. Verified no-regression: stashing the seam files leaves `BasicTests` identical.
