### PR TITLE
Add tabular operators: mv-apply, externaldata, make-series (#57), ipv4_lookup

### DIFF
--- a/docs/hostProvidedData.md
+++ b/docs/hostProvidedData.md
@@ -88,3 +88,18 @@ public IReadOnlyList<IReadOnlyList<string>> ResolveRows(string uri, string forma
 
 `DelimiterFor` maps the KQL delimited formats — `csv`, `tsv`/`tsve`, `scsv`, `sohsv`, `psv` — and
 `Parse` handles RFC4180 quoting.
+
+### Supported formats, and a note on JSON
+
+Only the **delimited** family is supported today. ADX additionally accepts `json`, `multijson`,
+`parquet`, `avro` and others.
+
+Delimited formats fit this contract naturally because cells are **positional** — the *n*th cell is
+the *n*th declared column. JSON is not positional: its properties map to columns **by name**, and
+the resolver is given the format but not the declared column names, so it cannot do that mapping.
+Supporting JSON therefore needs a deliberate decision rather than an incremental patch — either the
+contract grows to carry the declared column names, or the engine takes raw content and parses it
+itself (which would move format handling out of the host, away from the `LoadTablesAsync`
+convention this seam follows).
+
+That trade-off is left open on purpose rather than settled by whichever option was easiest to add.

--- a/docs/hostProvidedData.md
+++ b/docs/hostProvidedData.md
@@ -1,0 +1,90 @@
+# Host-provided data
+
+Some KQL functions and operators are backed by data the engine does not ship: an IP-geolocation
+database, a user-agent dataset, or a list fetched from external storage. Bundling those would force
+every consumer to take a dependency (and a licence) they may not want, so the engine defines the
+capability and the **host supplies the data**.
+
+This follows the same shape as `IKustoQueryContextTableLoader`: the host provides the data and owns
+the policy — where it comes from, what is allowed, caching, bounds — and the engine provides the
+query surface and helpers.
+
+Providers are registered per `KustoQueryContext`:
+
+```csharp
+var context = new KustoQueryContext();
+context.AddProvider<IGeoIpProvider>(myGeoProvider);
+```
+
+## `geo_info_from_ip_address` — `IGeoIpProvider`
+
+```csharp
+public interface IGeoIpProvider
+{
+    GeoIpInfo? Lookup(IPAddress address);
+}
+
+public sealed record GeoIpInfo(
+    string? Country = null, string? State = null, string? City = null,
+    double? Latitude = null, double? Longitude = null);
+```
+
+Returns the ADX shape `{country, state, city, latitude, longitude}`. Return `null` for an address you
+cannot resolve — the function then yields `null`, exactly as it does in ADX for an unknown address.
+With no provider registered the function still **binds** (a query using it is never rejected) and
+resolves to `null`, so a geo predicate is simply inert rather than an error.
+
+A ready-made provider backed by a DB-IP "IP to City Lite" export is available in the optional
+`KustoLoco.Geo` package.
+
+## `parse_user_agent` — `IUserAgentParser`
+
+```csharp
+public interface IUserAgentParser
+{
+    UserAgentInfo Parse(string userAgent);
+}
+```
+
+`UserAgentInfo` carries `Browser` and `OperatingSystem` (`Family`, `Major`, `Minor`, `Patch`,
+`PatchMinor`) and `Device` (`Family`, `Brand`, `Model`). As with geo, absent provider ⇒ `null`
+result, never a bind failure.
+
+A parser backed by the canonical `ua-parser/uap-core` dataset is available in the optional
+`KustoLoco.UserAgent` package.
+
+## `externaldata` — `IExternalDataResolver`
+
+```csharp
+public interface IExternalDataResolver
+{
+    IReadOnlyList<IReadOnlyList<string>> ResolveRows(string uri, string format);
+}
+
+context.SetExternalDataResolver(myResolver);
+```
+
+The engine performs **no network or file access of its own** and registers **no default resolver**,
+so `externaldata` reports an error until a host opts in. That is deliberate: the host is the only
+place that can decide which URI schemes are acceptable, what size and time bounds apply, and how to
+authenticate.
+
+Two rules matter when implementing one:
+
+- **Throw on failure.** Returning an empty set would turn an unreachable list into a silent
+  no-match — the worst outcome for a query whose purpose is matching against that list.
+- **Return rows of cells, not typed values.** The engine types each cell per the schema the query
+  declared, the same path a `datatable` literal takes.
+
+The engine publishes `DelimitedTextParser` so you do not have to reimplement the declared format:
+
+```csharp
+public IReadOnlyList<IReadOnlyList<string>> ResolveRows(string uri, string format)
+{
+    var text = Fetch(uri);                    // your transport, your policy
+    return DelimitedTextParser.Parse(text, DelimitedTextParser.DelimiterFor(format));
+}
+```
+
+`DelimiterFor` maps the KQL delimited formats — `csv`, `tsv`/`tsve`, `scsv`, `sohsv`, `psv` — and
+`Parse` handles RFC4180 quoting.

--- a/libraries/KustoLoco.Core/BabyKustoEngine.cs
+++ b/libraries/KustoLoco.Core/BabyKustoEngine.cs
@@ -27,6 +27,7 @@ public class BabyKustoEngine
     private Dictionary<FunctionSymbol, ScalarFunctionInfo> _additionalfuncs = new();
     private readonly IKustoConsole _console;
     private readonly KustoSettingsProvider _settings;
+    private ProviderRegistry _providers = new();
 
     public BabyKustoEngine(IKustoConsole console,KustoSettingsProvider settings)
     {
@@ -54,6 +55,17 @@ public class BabyKustoEngine
     {
         _additionalfuncs = funcs;
     }
+
+    // Register a host-supplied provider (for example an IGeoIpProvider) that context-aware scalar functions read at
+    // evaluation time. Absent providers leave their functions returning null (inert), so queries still run.
+    public BabyKustoEngine AddProvider<T>(T provider) where T : class
+    {
+        _providers.Set(provider);
+        return this;
+    }
+
+    // Use a caller-owned provider registry (e.g. one held by KustoQueryContext across query runs).
+    internal void UseProviders(ProviderRegistry providers) => _providers = providers;
 
     public IReadOnlyCollection<AggregateInfo> GetImplementedAggregateList()
     {
@@ -147,7 +159,7 @@ public class BabyKustoEngine
         var scope = new LocalScope();
         foreach (var table in tables) scope.AddSymbol(table.Type, TabularResult.CreateUnvisualized(table));
 
-        var result = BabyKustoEvaluator.Evaluate(ir, scope);
+        var result = BabyKustoEvaluator.Evaluate(ir, scope, _providers);
         return result;
     }
 

--- a/libraries/KustoLoco.Core/DelimitedTextParser.cs
+++ b/libraries/KustoLoco.Core/DelimitedTextParser.cs
@@ -1,0 +1,90 @@
+//
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace KustoLoco.Core;
+
+/// <summary>
+/// Splits delimited text into rows of string cells, following the delimiter implied by a KQL
+/// <c>with (format=...)</c> specifier. Provided by the engine so a host writing an
+/// <see cref="IExternalDataResolver"/> does not have to reimplement delimited parsing: the host owns transport and
+/// policy, the engine owns the format the query declared.
+/// </summary>
+public static class DelimitedTextParser
+{
+    /// <summary>
+    /// The delimiter for a KQL data format name. The delimited family is csv / tsv / tsve / scsv / sohsv / psv;
+    /// anything else (including an absent format) falls back to comma, matching the KQL default.
+    /// </summary>
+    public static char DelimiterFor(string? format) => (format?.Trim().ToLowerInvariant()) switch
+    {
+        "tsv" or "tsve" => '\t',
+        "scsv" => ';',
+        "sohsv" => '',
+        "psv" => '|',
+        _ => ',',
+    };
+
+    /// <summary>
+    /// Parse delimited <paramref name="content"/> into rows of cells. Fields may be double-quoted, in which case a
+    /// doubled quote is a literal quote and the delimiter and line breaks are taken literally (RFC4180). Blank lines
+    /// are skipped. Line endings may be CRLF or LF.
+    /// </summary>
+    public static IReadOnlyList<IReadOnlyList<string>> Parse(string content, char delimiter)
+    {
+        var rows = new List<IReadOnlyList<string>>();
+        if (string.IsNullOrEmpty(content))
+            return rows;
+
+        var row = new List<string>();
+        var cell = new StringBuilder();
+        var inQuotes = false;
+        var cellWasQuoted = false;
+
+        void EndCell()
+        {
+            row.Add(cell.ToString());
+            cell.Clear();
+            cellWasQuoted = false;
+        }
+
+        void EndRow()
+        {
+            EndCell();
+            // A blank line (one empty, unquoted cell) carries no data.
+            if (row.Count > 1 || row[0].Length > 0)
+                rows.Add(row.ToArray());
+            row.Clear();
+        }
+
+        for (var i = 0; i < content.Length; i++)
+        {
+            var c = content[i];
+
+            if (inQuotes)
+            {
+                if (c == '"')
+                {
+                    if (i + 1 < content.Length && content[i + 1] == '"') { cell.Append('"'); i++; }
+                    else inQuotes = false;
+                }
+                else cell.Append(c);
+                continue;
+            }
+
+            if (c == '"' && cell.Length == 0 && !cellWasQuoted) { inQuotes = true; cellWasQuoted = true; }
+            else if (c == delimiter) EndCell();
+            else if (c == '\r') { /* handled by the \n that follows, or ignored at EOF */ }
+            else if (c == '\n') EndRow();
+            else cell.Append(c);
+        }
+
+        // Trailing content with no final newline is still a row.
+        if (cell.Length > 0 || row.Count > 0) EndRow();
+
+        return rows;
+    }
+}

--- a/libraries/KustoLoco.Core/Evaluation/BabyKustoEvaluator.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BabyKustoEvaluator.cs
@@ -7,9 +7,9 @@ namespace KustoLoco.Core.Evaluation;
 
 internal static class BabyKustoEvaluator
 {
-    internal static EvaluationResult Evaluate(IRNode root, LocalScope scope)
+    internal static EvaluationResult Evaluate(IRNode root, LocalScope scope, IProviderRegistry? providers = null)
     {
         var evaluator = new TreeEvaluator();
-        return root.Accept(evaluator, new EvaluationContext(scope));
+        return root.Accept(evaluator, new EvaluationContext(scope) { Providers = providers });
     }
 }

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
@@ -352,5 +352,6 @@ internal static class BuiltInScalarFunctions
         SetIntersectFunctionImpl.Register(Functions);
         SetDifferenceFunctionImpl.Register(Functions);
         GeoInfoFromIpFunctionImpl.Register(Functions);
+        ParseUserAgentFunctionImpl.Register(Functions);
     }
 }

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
@@ -199,6 +199,10 @@ internal static class BuiltInScalarFunctions
         IsEmptyFunction.Register(Functions);
         IsNotEmptyFunction.Register(Functions);
         Ipv4IsPrivateFunction.Register(Functions);
+        Ipv4IsInRangeFunction.Register(Functions);
+        Ipv4IsInAnyRangeFunction.Register(Functions);
+        Ipv4IsMatchFunction.Register(Functions);
+        Ipv4CompareFunction.Register(Functions);
         ParseIpv4Function.Register(Functions);
         ParseIpv6Function.Register(Functions);
         IsAsciiFunction.Register(Functions);
@@ -320,6 +324,10 @@ internal static class BuiltInScalarFunctions
         UrlEncodeFunction.Register(Functions);
         RegexQuoteFunction.Register(Functions);
         RepeatFunction.Register(Functions);
+
+        SetHasElementFunction.Register(Functions);
+        BagKeysFunction.Register(Functions);
+        ExtractAllFunction.Register(Functions);
 
         //can't generate because arbitrary number of arguments
         BagPackFunctionImpl.Register(Functions);

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
@@ -207,6 +207,11 @@ internal static class BuiltInScalarFunctions
         FormatIpv4MaskFunction.Register(Functions);
         Ipv4NetmaskSuffixFunction.Register(Functions);
         ParseIpv4MaskFunction.Register(Functions);
+        Ipv4RangeToCidrListFunction.Register(Functions);
+        HasIpv4Function.Register(Functions);
+        HasIpv4PrefixFunction.Register(Functions);
+        HasAnyIpv4Function.Register(Functions);
+        HasAnyIpv4PrefixFunction.Register(Functions);
         ParseIpv4Function.Register(Functions);
         ParseIpv6Function.Register(Functions);
         IsAsciiFunction.Register(Functions);

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
@@ -337,5 +337,8 @@ internal static class BuiltInScalarFunctions
         BagPackFunctionImpl.Register(Functions);
         BagMergeFunctionImpl.Register(Functions);
         PackAllFunctionImpl.Register(Functions);
+        SetUnionFunctionImpl.Register(Functions);
+        SetIntersectFunctionImpl.Register(Functions);
+        SetDifferenceFunctionImpl.Register(Functions);
     }
 }

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
@@ -327,6 +327,10 @@ internal static class BuiltInScalarFunctions
 
         SetHasElementFunction.Register(Functions);
         BagKeysFunction.Register(Functions);
+        BagHasKeyFunction.Register(Functions);
+        BagRemoveKeysFunction.Register(Functions);
+        BagSetKeyFunction.Register(Functions);
+        BagZipFunction.Register(Functions);
         ExtractAllFunction.Register(Functions);
 
         //can't generate because arbitrary number of arguments

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
@@ -203,6 +203,10 @@ internal static class BuiltInScalarFunctions
         Ipv4IsInAnyRangeFunction.Register(Functions);
         Ipv4IsMatchFunction.Register(Functions);
         Ipv4CompareFunction.Register(Functions);
+        FormatIpv4Function.Register(Functions);
+        FormatIpv4MaskFunction.Register(Functions);
+        Ipv4NetmaskSuffixFunction.Register(Functions);
+        ParseIpv4MaskFunction.Register(Functions);
         ParseIpv4Function.Register(Functions);
         ParseIpv6Function.Register(Functions);
         IsAsciiFunction.Register(Functions);

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
@@ -351,5 +351,6 @@ internal static class BuiltInScalarFunctions
         SetUnionFunctionImpl.Register(Functions);
         SetIntersectFunctionImpl.Register(Functions);
         SetDifferenceFunctionImpl.Register(Functions);
+        GeoInfoFromIpFunctionImpl.Register(Functions);
     }
 }

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInScalarFunctions.cs
@@ -332,6 +332,8 @@ internal static class BuiltInScalarFunctions
         BagSetKeyFunction.Register(Functions);
         BagZipFunction.Register(Functions);
         ExtractAllFunction.Register(Functions);
+        ParseUrlFunction.Register(Functions);
+        ParseUrlQueryFunction.Register(Functions);
 
         //can't generate because arbitrary number of arguments
         BagPackFunctionImpl.Register(Functions);

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInsHelper.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/BuiltInsHelper.cs
@@ -120,11 +120,19 @@ internal static class BuiltInsHelper
         return false;
     }
 
+    // A context-aware scalar function receives the EvaluationContext (e.g. to reach a registered provider); every other
+    // function uses the existing context-free path unchanged.
+    private static ScalarResult InvokeScalarCtx(IScalarFunctionImpl impl, ScalarResult[] args, EvaluationContext ctx) =>
+        impl is IContextualScalarFunctionImpl c ? c.InvokeScalar(args, ctx) : impl.InvokeScalar(args);
+
+    private static ColumnarResult InvokeColumnarCtx(IScalarFunctionImpl impl, ColumnarResult[] args, EvaluationContext ctx) =>
+        impl is IContextualScalarFunctionImpl c ? c.InvokeColumnar(args, ctx) : impl.InvokeColumnar(args);
+
     private static EvaluationResult CreateResultForScalarInvocation(IScalarFunctionImpl impl,
-        EvaluationResult[] arguments, TypeSymbol expectedResultType)
+        EvaluationResult[] arguments, TypeSymbol expectedResultType, EvaluationContext context)
     {
         var scalarArgs = arguments.Cast<ScalarResult>().ToArray();
-        var result = impl.InvokeScalar(scalarArgs);
+        var result = InvokeScalarCtx(impl, scalarArgs, context);
         MyDebug.Assert(result.Type.Simplify() == expectedResultType.Simplify(),
             $"Evaluation produced wrong type {SchemaDisplay.GetText(result.Type)}, expected {SchemaDisplay.GetText(expectedResultType)}");
         return result;
@@ -167,7 +175,7 @@ internal static class BuiltInsHelper
 
 
     private static EvaluationResult CreateResultForColumnarInvocation(IScalarFunctionImpl impl,
-        EvaluationResult[] arguments, TypeSymbol expectedResultType, EvaluationHints hints)
+        EvaluationResult[] arguments, TypeSymbol expectedResultType, EvaluationHints hints, EvaluationContext context)
     {
         var columnarArgs = CreateResultArray(arguments);
 
@@ -188,26 +196,29 @@ internal static class BuiltInsHelper
         {
             var logicalRowCount = columnarArgs.Max(c => c.RowCount);
             columnarArgs = columnarArgs.Select(c => c.SliceToTopRow()).ToArray();
-            var topRowResult = impl.InvokeColumnar(columnarArgs);
+            var topRowResult = InvokeColumnarCtx(impl, columnarArgs, context);
             return topRowResult.Inflate(logicalRowCount);
         }
 
-        var result = impl.InvokeColumnar(columnarArgs);
+        var result = InvokeColumnarCtx(impl, columnarArgs, context);
         MyDebug.Assert(result.Type.Simplify() == expectedResultType.Simplify(),
             $"Evaluation produced wrong type {SchemaDisplay.GetText(result.Type)}, expected {SchemaDisplay.GetText(expectedResultType)}");
         return result;
     }
 
     // TODO: Support named parameters
-    public static Func<EvaluationResult[], EvaluationResult> GetScalarImplementation(IScalarFunctionImpl impl,
+    // The invocation now receives the EvaluationContext so a context-aware function can reach per-query state
+    // (e.g. a registered provider); context-free functions ignore it.
+    public static Func<EvaluationResult[], EvaluationContext, EvaluationResult> GetScalarImplementation(
+        IScalarFunctionImpl impl,
         EvaluatedExpressionKind resultKind,
         TypeSymbol expectedResultType, EvaluationHints hints) =>
         resultKind switch
         {
-            EvaluatedExpressionKind.Scalar => arguments =>
-                CreateResultForScalarInvocation(impl, arguments, expectedResultType),
-            EvaluatedExpressionKind.Columnar => arguments =>
-                CreateResultForColumnarInvocation(impl, arguments, expectedResultType, hints),
+            EvaluatedExpressionKind.Scalar => (arguments, context) =>
+                CreateResultForScalarInvocation(impl, arguments, expectedResultType, context),
+            EvaluatedExpressionKind.Columnar => (arguments, context) =>
+                CreateResultForColumnarInvocation(impl, arguments, expectedResultType, hints, context),
             _ => throw new InvalidOperationException($"Unexpected result kind {resultKind}")
         };
 

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/Infra/IContextualScalarFunctionImpl.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/Infra/IContextualScalarFunctionImpl.cs
@@ -1,0 +1,20 @@
+//
+// Licensed under the MIT License.
+
+using KustoLoco.Core.Evaluation;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns;
+
+/// <summary>
+///     A scalar function that also needs the per-query <see cref="EvaluationContext" /> (for example to reach a
+///     host-registered provider via <c>context.Providers</c>). A function implements this in addition to being a normal
+///     <see cref="IScalarFunctionImpl" />; when the evaluator sees it, it passes the context into the invocation. This
+///     realises the standing TODO to thread <see cref="EvaluationContext" /> into scalar invocation without changing the
+///     signature every other function depends on.
+/// </summary>
+internal interface IContextualScalarFunctionImpl
+{
+    ScalarResult InvokeScalar(ScalarResult[] arguments, EvaluationContext context);
+
+    ColumnarResult InvokeColumnar(ColumnarResult[] arguments, EvaluationContext context);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/BagHasKeyFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/BagHasKeyFunction.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// bag_has_key(bag, key) -> true iff the dynamic object has the given top-level key; null when 'bag' is not an object.
+[KustoImplementation(Keyword = "Functions.BagHasKey")]
+internal partial class BagHasKeyFunction
+{
+    private static bool? Impl(JsonNode bag, string key) => DynamicSetSupport.HasKey(bag, key);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/BagKeysFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/BagKeysFunction.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// bag_keys(bag) -> the top-level property names of a dynamic property bag as a string array; null when the argument is
+// not a dynamic object.
+[KustoImplementation(Keyword = "Functions.BagKeys")]
+internal partial class BagKeysFunction
+{
+    private static JsonNode? Impl(JsonNode bag) => DynamicSetSupport.Keys(bag);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/BagRemoveKeysFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/BagRemoveKeysFunction.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// bag_remove_keys(bag, keys) -> a copy of the dynamic object with the named top-level keys removed; null when the
+// arguments are not an object / array.
+[KustoImplementation(Keyword = "Functions.BagRemoveKeys")]
+internal partial class BagRemoveKeysFunction
+{
+    private static JsonNode? Impl(JsonNode bag, JsonNode keys) => DynamicSetSupport.RemoveKeys(bag, keys);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/BagSetKeyFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/BagSetKeyFunction.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// bag_set_key(bag, key, value) -> a copy of the dynamic object with 'key' set to 'value'; null when 'bag' is not an
+// object. The value argument is polymorphic in ADX, so one overload per scalar type.
+[KustoImplementation(Keyword = "Functions.BagSetKey")]
+internal partial class BagSetKeyFunction
+{
+    private static JsonNode? StringImpl(JsonNode bag, string key, string value) => DynamicSetSupport.SetKey(bag, key, JsonValue.Create(value));
+    private static JsonNode? LongImpl(JsonNode bag, string key, long value) => DynamicSetSupport.SetKey(bag, key, JsonValue.Create(value));
+    private static JsonNode? RealImpl(JsonNode bag, string key, double value) => DynamicSetSupport.SetKey(bag, key, JsonValue.Create(value));
+    private static JsonNode? BoolImpl(JsonNode bag, string key, bool value) => DynamicSetSupport.SetKey(bag, key, JsonValue.Create(value));
+    private static JsonNode? Impl(JsonNode bag, string key, JsonNode value) => DynamicSetSupport.SetKey(bag, key, value);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/BagZipFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/BagZipFunction.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// bag_zip(keys, values) -> a dynamic object pairing keys[i] with values[i]. Null when either argument is not a
+// dynamic array.
+[KustoImplementation(Keyword = "Functions.BagZip")]
+internal partial class BagZipFunction
+{
+    private static JsonNode? Impl(JsonNode keys, JsonNode values) => DynamicSetSupport.Zip(keys, values);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/DynamicSetSupport.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/DynamicSetSupport.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// Shared helpers for the dynamic bag/set scalars. A separate class because the source generator INLINES an Impl body,
+// so an Impl must not call a private same-class helper.
+internal static class DynamicSetSupport
+{
+    // bag_keys(bag) -> the top-level property names of a dynamic object as a string array; null when not an object.
+    public static JsonNode? Keys(JsonNode bag)
+    {
+        if (bag is not JsonObject o) return null;
+        var arr = new JsonArray();
+        foreach (var kv in o) arr.Add(kv.Key);
+        return arr;
+    }
+
+    // set_has_element membership by JSON value-equality: compare canonical JSON text so string / number / bool / nested
+    // all behave consistently. Null when the set argument is not a dynamic array.
+    public static bool? Has(JsonNode set, JsonNode? value)
+    {
+        if (set is not JsonArray arr) return null;
+        var target = value?.ToJsonString();
+        foreach (var el in arr)
+            if (string.Equals(el?.ToJsonString(), target, StringComparison.Ordinal)) return true;
+        return false;
+    }
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/DynamicSetSupport.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/DynamicSetSupport.cs
@@ -26,4 +26,50 @@ internal static class DynamicSetSupport
             if (string.Equals(el?.ToJsonString(), target, StringComparison.Ordinal)) return true;
         return false;
     }
+
+    // bag_has_key(bag, key) -> true iff the top-level key is present; null when the bag argument is not an object.
+    public static bool? HasKey(JsonNode bag, string key)
+    {
+        if (bag is not JsonObject o) return null;
+        return o.ContainsKey(key);
+    }
+
+    // bag_remove_keys(bag, keys) -> a copy of the bag without the named top-level keys; null when the arguments are not
+    // an object / array.
+    public static JsonNode? RemoveKeys(JsonNode bag, JsonNode keys)
+    {
+        if (bag is not JsonObject o || keys is not JsonArray arr) return null;
+        var clone = (JsonObject)o.DeepClone();
+        foreach (var k in arr)
+        {
+            var key = k?.ToString();
+            if (key != null) clone.Remove(key);
+        }
+        return clone;
+    }
+
+    // bag_set_key(bag, key, value) -> a copy of the bag with key set to value; null when the bag argument is not an
+    // object. A null bag key argument is a no-op copy.
+    public static JsonNode? SetKey(JsonNode bag, string? key, JsonNode? value)
+    {
+        if (bag is not JsonObject o) return null;
+        var clone = (JsonObject)o.DeepClone();
+        if (key != null) clone[key] = value?.DeepClone();
+        return clone;
+    }
+
+    // bag_zip(keys, values) -> an object pairing keys[i] with values[i]; a longer keys array pads with null, a longer
+    // values array ignores the surplus. Null when either argument is not a dynamic array.
+    public static JsonNode? Zip(JsonNode keys, JsonNode values)
+    {
+        if (keys is not JsonArray ka || values is not JsonArray va) return null;
+        var obj = new JsonObject();
+        for (var i = 0; i < ka.Count; i++)
+        {
+            var key = ka[i]?.ToString();
+            if (key == null) continue;
+            obj[key] = i < va.Count ? va[i]?.DeepClone() : null;
+        }
+        return obj;
+    }
 }

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/ExtractAllFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/ExtractAllFunction.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// extract_all(regex, source) / extract_all(regex, captureGroups, source) -> dynamic. ADX shape: 0 capture groups ->
+// the full matches; 1 group -> that group per match; >1 groups (or an explicit captureGroups list) -> an array of
+// arrays. A bad pattern or a match-timeout (ReDoS guard) -> null; no match -> an empty array.
+[KustoImplementation(Keyword = "Functions.ExtractAll")]
+internal partial class ExtractAllFunction
+{
+    private static JsonNode? Impl(string regex, string source) => ExtractAllSupport.Extract(regex, source, null);
+
+    private static JsonNode? GroupsImpl(string regex, JsonNode captureGroups, string source)
+        => ExtractAllSupport.Extract(regex, source, captureGroups);
+}
+
+// Separate class: the source generator inlines an Impl body, so an Impl must not call a private same-class helper.
+internal static class ExtractAllSupport
+{
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
+
+    public static JsonNode? Extract(string? pattern, string? source, JsonNode? captureGroups)
+    {
+        if (string.IsNullOrEmpty(pattern) || source is null) return null;
+        Regex rx;
+        try { rx = new Regex(pattern, RegexOptions.CultureInvariant, RegexTimeout); }
+        catch (ArgumentException) { return null; }
+
+        var matches = new List<Match>();
+        try { foreach (Match m in rx.Matches(source)) matches.Add(m); }
+        catch (RegexMatchTimeoutException) { return null; }
+        if (matches.Count == 0) return new JsonArray();
+
+        if (captureGroups is JsonArray wantedArr)
+        {
+            var wanted = new List<int>();
+            foreach (var el in wantedArr)
+            {
+                if (el is JsonValue v && v.TryGetValue<long>(out var l)) wanted.Add((int)l);
+                else if (el is JsonValue vs && vs.TryGetValue<string>(out var s) && int.TryParse(s, out var pi)) wanted.Add(pi);
+                else return null;
+            }
+            var outer = new JsonArray();
+            foreach (var m in matches)
+            {
+                var row = new JsonArray();
+                foreach (var g in wanted)
+                    row.Add(g >= 0 && g < m.Groups.Count && m.Groups[g].Success ? JsonValue.Create(m.Groups[g].Value) : null);
+                outer.Add(row);
+            }
+            return outer;
+        }
+
+        var groupCount = rx.GetGroupNumbers().Length - 1;   // minus the implicit whole-match group 0
+        var result = new JsonArray();
+        if (groupCount <= 0)
+            foreach (var m in matches) result.Add(JsonValue.Create(m.Value));
+        else if (groupCount == 1)
+            foreach (var m in matches) result.Add(m.Groups[1].Success ? JsonValue.Create(m.Groups[1].Value) : null);
+        else
+            foreach (var m in matches)
+            {
+                var row = new JsonArray();
+                for (var g = 1; g <= groupCount; g++)
+                    row.Add(m.Groups[g].Success ? JsonValue.Create(m.Groups[g].Value) : null);
+                result.Add(row);
+            }
+        return result;
+    }
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/FormatIpv4Function.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/FormatIpv4Function.cs
@@ -1,0 +1,10 @@
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// format_ipv4(ip [, prefix]) -> the network address masked to the effective prefix (default 32) as dotted-quad; null
+// when the address is unparseable or the prefix is out of range.
+[KustoImplementation(Keyword = "Functions.FormatIPV4")]
+internal partial class FormatIpv4Function
+{
+    private static string? Impl(string ip) => Ipv4Support.FormatV4(ip, null);
+    private static string? PrefixImpl(string ip, long prefix) => Ipv4Support.FormatV4(ip, prefix);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/FormatIpv4MaskFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/FormatIpv4MaskFunction.cs
@@ -1,0 +1,9 @@
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// format_ipv4_mask(ip, prefix) -> the masked network address in CIDR notation; null when the address is unparseable or
+// the prefix is out of range.
+[KustoImplementation(Keyword = "Functions.FormatIPV4Mask")]
+internal partial class FormatIpv4MaskFunction
+{
+    private static string? Impl(string ip, long prefix) => Ipv4Support.FormatV4Mask(ip, prefix);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/GeoInfoFromIpFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/GeoInfoFromIpFunction.cs
@@ -1,0 +1,62 @@
+//
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Net;
+using System.Text.Json.Nodes;
+using Kusto.Language;
+using Kusto.Language.Symbols;
+using KustoLoco.Core.DataSource;
+using KustoLoco.Core.DataSource.Columns;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// geo_info_from_ip_address(ip) -> dynamic { country, state, city, latitude, longitude } resolved by the
+// host-registered IGeoIpProvider (read from EvaluationContext.Providers). No provider registered, an unparseable
+// address, or an unresolved address all yield null, so geo predicates stay inert rather than failing the query. This
+// is a context-aware scalar (IContextualScalarFunctionImpl): the engine ships no geo database, the host supplies it.
+internal class GeoInfoFromIpFunctionImpl : IScalarFunctionImpl, IContextualScalarFunctionImpl
+{
+    // The context-free path is never taken (the evaluator routes context-aware impls to the context method); it exists
+    // for interface completeness and degrades to "no provider" -> null.
+    public ScalarResult InvokeScalar(ScalarResult[] arguments) => InvokeScalar(arguments, default);
+
+    public ColumnarResult InvokeColumnar(ColumnarResult[] arguments) => InvokeColumnar(arguments, default);
+
+    public ScalarResult InvokeScalar(ScalarResult[] arguments, EvaluationContext context)
+    {
+        var provider = context.Providers?.Get<IGeoIpProvider>();
+        return new ScalarResult(ScalarTypes.Dynamic, Lookup(provider, arguments[0].Value as string));
+    }
+
+    public ColumnarResult InvokeColumnar(ColumnarResult[] arguments, EvaluationContext context)
+    {
+        var provider = context.Providers?.Get<IGeoIpProvider>();
+        var rowCount = arguments[0].Column.RowCount;
+        var data = NullableSetBuilderOfJsonNode.CreateFixed(rowCount);
+        for (var row = 0; row < rowCount; row++)
+            data[row] = Lookup(provider, arguments[0].Column.GetRawDataValue(row) as string);
+        return new ColumnarResult(GenericColumnFactoryOfJsonNode.CreateFromDataSet(data.ToNullableSet()));
+    }
+
+    private static JsonNode? Lookup(IGeoIpProvider? provider, string? ip)
+    {
+        if (provider is null || string.IsNullOrEmpty(ip) || !IPAddress.TryParse(ip, out var address))
+            return null;
+        var info = provider.Lookup(address);
+        if (info is null) return null;
+        return new JsonObject
+        {
+            ["country"] = info.Country is null ? null : JsonValue.Create(info.Country),
+            ["state"] = info.State is null ? null : JsonValue.Create(info.State),
+            ["city"] = info.City is null ? null : JsonValue.Create(info.City),
+            ["latitude"] = info.Latitude is null ? null : JsonValue.Create(info.Latitude.Value),
+            ["longitude"] = info.Longitude is null ? null : JsonValue.Create(info.Longitude.Value),
+        };
+    }
+
+    internal static void Register(Dictionary<FunctionSymbol, ScalarFunctionInfo> functions) =>
+        functions.Add(Functions.IpGeoLocation,
+            new ScalarFunctionInfo(new ScalarOverloadInfo(
+                new GeoInfoFromIpFunctionImpl(), ScalarTypes.Dynamic, ScalarTypes.String)));
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/HasAnyIpv4Function.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/HasAnyIpv4Function.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// has_any_ipv4(source, ips) -> true iff 'source' contains ANY of the IPv4 addresses in the dynamic array as a term.
+[KustoImplementation(Keyword = "Functions.HasAnyIpv4")]
+internal partial class HasAnyIpv4Function
+{
+    private static bool? Impl(string source, JsonNode ips) => Ipv4Support.HasAny(source, ips, asPrefix: false);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/HasAnyIpv4PrefixFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/HasAnyIpv4PrefixFunction.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// has_any_ipv4_prefix(source, ip_prefixes) -> true iff 'source' contains an IPv4 term matching ANY of the prefixes in
+// the dynamic array.
+[KustoImplementation(Keyword = "Functions.HasAnyIpv4Prefix")]
+internal partial class HasAnyIpv4PrefixFunction
+{
+    private static bool? Impl(string source, JsonNode ipPrefixes) => Ipv4Support.HasAny(source, ipPrefixes, asPrefix: true);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/HasIpv4Function.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/HasIpv4Function.cs
@@ -1,0 +1,9 @@
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// has_ipv4(source, ip) -> true iff 'source' contains the IPv4 'ip' as a properly delimited term; null when 'ip' is not
+// a valid IPv4 address.
+[KustoImplementation(Keyword = "Functions.HasIpv4")]
+internal partial class HasIpv4Function
+{
+    private static bool? Impl(string source, string ip) => Ipv4Support.HasIp(source, ip);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/HasIpv4PrefixFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/HasIpv4PrefixFunction.cs
@@ -1,0 +1,9 @@
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// has_ipv4_prefix(source, ip_prefix) -> true iff 'source' contains an IPv4 term whose leading octets match 'ip_prefix'
+// (e.g. "10.1."); null when the prefix is malformed.
+[KustoImplementation(Keyword = "Functions.HasIpv4Prefix")]
+internal partial class HasIpv4PrefixFunction
+{
+    private static bool? Impl(string source, string ipPrefix) => Ipv4Support.HasIpPrefix(source, ipPrefix);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4CompareFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4CompareFunction.cs
@@ -1,0 +1,10 @@
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// ipv4_compare(ip1, ip2 [, prefix]) -> -1/0/1 comparing two IPv4 addresses over the effective prefix (default 32; each
+// operand may also carry its own /prefix). Null when either address is unparseable.
+[KustoImplementation(Keyword = "Functions.Ipv4Compare")]
+internal partial class Ipv4CompareFunction
+{
+    private static long? Impl(string ip1, string ip2) => Ipv4Support.MaskedCompare(ip1, ip2, null);
+    private static long? PrefixImpl(string ip1, string ip2, long prefix) => Ipv4Support.MaskedCompare(ip1, ip2, prefix);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4IsInAnyRangeFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4IsInAnyRangeFunction.cs
@@ -1,0 +1,37 @@
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// ipv4_is_in_any_range(ip, ranges) -> true iff the IPv4 'ip' is inside ANY of the CIDR ranges in the dynamic array;
+// false if in none; null when 'ip' is unparseable or 'ranges' is not a dynamic array.
+[KustoImplementation(Keyword = "Functions.Ipv4IsInAnyRange")]
+internal partial class Ipv4IsInAnyRangeFunction
+{
+    private static bool? Impl(string ip, JsonNode ranges)
+    {
+        if (string.IsNullOrEmpty(ip) || ranges is not JsonArray arr) return null;
+        if (!Ipv4Support.TryParse(ip, out var ipv)) return null;
+        foreach (var item in arr)
+        {
+            var cidr = item?.ToString();
+            if (string.IsNullOrEmpty(cidr)) continue;
+            uint basev;
+            int bits;
+            var slash = cidr.IndexOf('/');
+            if (slash < 0)
+            {
+                // a bare address in the list is an exact (/32) match, as in ADX.
+                if (!Ipv4Support.TryParse(cidr, out basev)) continue;
+                bits = 32;
+            }
+            else
+            {
+                if (!Ipv4Support.TryParse(cidr.Substring(0, slash), out basev)) continue;
+                if (!int.TryParse(cidr.Substring(slash + 1), out bits) || bits < 0 || bits > 32) continue;
+            }
+            var mask = bits == 0 ? 0u : 0xFFFFFFFFu << (32 - bits);
+            if ((ipv & mask) == (basev & mask)) return true;
+        }
+        return false;
+    }
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4IsInRangeFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4IsInRangeFunction.cs
@@ -1,0 +1,8 @@
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// ipv4_is_in_range(ip, ip_range) -> true iff the IPv4 'ip' is inside the CIDR 'ip_range'. Null on unparseable/malformed.
+[KustoImplementation(Keyword = "Functions.Ipv4IsInRange")]
+internal partial class Ipv4IsInRangeFunction
+{
+    private static bool? Impl(string ip, string cidr) => Ipv4Support.InRange(ip, cidr);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4IsMatchFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4IsMatchFunction.cs
@@ -1,0 +1,10 @@
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// ipv4_is_match(ip1, ip2 [, prefix]) -> true iff two IPv4 addresses match over the effective prefix (default 32; each
+// operand may also carry its own /prefix). Null when either address is unparseable.
+[KustoImplementation(Keyword = "Functions.Ipv4IsMatch")]
+internal partial class Ipv4IsMatchFunction
+{
+    private static bool? Impl(string ip1, string ip2) => Ipv4Support.MaskedEqual(ip1, ip2, null);
+    private static bool? PrefixImpl(string ip1, string ip2, long prefix) => Ipv4Support.MaskedEqual(ip1, ip2, prefix);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4NetmaskSuffixFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4NetmaskSuffixFunction.cs
@@ -1,0 +1,8 @@
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// ipv4_netmask_suffix(ip_range) -> the /suffix of a CIDR (32 when none present); null when the address is unparseable.
+[KustoImplementation(Keyword = "Functions.Ipv4NetmaskSuffix")]
+internal partial class Ipv4NetmaskSuffixFunction
+{
+    private static long? Impl(string ipRange) => Ipv4Support.NetmaskSuffix(ipRange);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4RangeToCidrListFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4RangeToCidrListFunction.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// ipv4_range_to_cidr_list(start_ip, end_ip) -> the minimal ordered array of CIDR blocks covering the inclusive range;
+// null when either address is unparseable or start > end.
+[KustoImplementation(Keyword = "Functions.Ipv4RangeToCidrList")]
+internal partial class Ipv4RangeToCidrListFunction
+{
+    private static JsonNode? Impl(string startIp, string endIp) => Ipv4Support.RangeToCidrList(startIp, endIp);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4Support.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4Support.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
+using System.Numerics;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
 
 namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
 
@@ -83,6 +86,72 @@ internal static class Ipv4Support
     {
         var v = MaskedValue(ip, prefix);
         return v is null ? null : (long)v.Value;
+    }
+
+    // ipv4_range_to_cidr_list: the minimal ordered list of CIDR blocks that exactly covers [start_ip, end_ip].
+    public static JsonNode? RangeToCidrList(string startIp, string endIp)
+    {
+        if (!TryParse(startIp, out var start) || !TryParse(endIp, out var end) || start > end) return null;
+        var result = new JsonArray();
+        ulong s = start;
+        ulong e = end;
+        while (s <= e)
+        {
+            // Largest block the current start is aligned for, capped by how many addresses remain.
+            var maxByAlign = s == 0 ? 32 : BitOperations.TrailingZeroCount((uint)s);
+            var maxByCount = BitOperations.Log2(e - s + 1);
+            var blockBits = (int)Math.Min(maxByAlign, maxByCount);
+            result.Add($"{UintToDotted((uint)s)}/{32 - blockBits}");
+            s += 1UL << blockBits;
+        }
+        return result;
+    }
+
+    // has_ipv4 / has_ipv4_prefix scan for IPv4 terms delimited by non-alphanumeric, non-dot characters (so a substring
+    // of a longer number or word is not a match), matching ADX term semantics.
+    private static readonly Regex Ipv4Term =
+        new(@"(?<![0-9A-Za-z.])(\d{1,3}\.){3}\d{1,3}(?![0-9A-Za-z.])", RegexOptions.CultureInvariant);
+
+    public static bool? HasIp(string? source, string ip)
+    {
+        if (source is null) return null;
+        if (!TryParse(ip, out var target)) return null;
+        foreach (Match m in Ipv4Term.Matches(source))
+            if (TryParse(m.Value, out var v) && v == target) return true;
+        return false;
+    }
+
+    public static bool? HasIpPrefix(string? source, string prefix)
+    {
+        if (source is null) return null;
+        var parts = (prefix ?? "").TrimEnd('.').Split('.');
+        if (parts.Length is 0 or > 4) return null;
+        var octets = new int[parts.Length];
+        for (var i = 0; i < parts.Length; i++)
+            if (!int.TryParse(parts[i], out octets[i]) || octets[i] < 0 || octets[i] > 255) return null;
+        foreach (Match m in Ipv4Term.Matches(source))
+        {
+            var cand = m.Value.Split('.');
+            if (cand.Length != 4) continue;
+            var ok = true;
+            for (var i = 0; i < octets.Length; i++)
+                if (!int.TryParse(cand[i], out var o) || o != octets[i]) { ok = false; break; }
+            if (ok) return true;
+        }
+        return false;
+    }
+
+    public static bool? HasAny(string? source, JsonNode needles, bool asPrefix)
+    {
+        if (source is null || needles is not JsonArray arr) return null;
+        foreach (var item in arr)
+        {
+            var needle = item?.ToString();
+            if (string.IsNullOrEmpty(needle)) continue;
+            var hit = asPrefix ? HasIpPrefix(source, needle) : HasIp(source, needle);
+            if (hit == true) return true;
+        }
+        return false;
     }
 
     public static bool? MaskedEqual(string a, string b, long? prefixArg)

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4Support.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4Support.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// Shared helpers for the ipv4_* family. A separate class because the source generator INLINES an Impl body, so an Impl
+// must not call a private same-class helper. IPv4 addresses are held as a big-endian uint for mask/compare arithmetic.
+internal static class Ipv4Support
+{
+    public static bool TryParse(string s, out uint value)
+    {
+        value = 0;
+        if (!IPAddress.TryParse(s, out var ip) || ip.AddressFamily != AddressFamily.InterNetwork) return false;
+        var b = ip.GetAddressBytes();
+        value = ((uint)b[0] << 24) | ((uint)b[1] << 16) | ((uint)b[2] << 8) | b[3];
+        return true;
+    }
+
+    // Split "a.b.c.d[/prefix]" into address + prefix (32 when no suffix; a malformed suffix -> 32).
+    public static int SplitPrefix(string token, out string ip)
+    {
+        var slash = token.IndexOf('/');
+        if (slash < 0) { ip = token; return 32; }
+        ip = token.Substring(0, slash);
+        return int.TryParse(token.Substring(slash + 1), out var p) && p >= 0 && p <= 32 ? p : 32;
+    }
+
+    public static bool? InRange(string ip, string cidr)
+    {
+        if (string.IsNullOrEmpty(ip) || string.IsNullOrEmpty(cidr)) return null;
+        var slash = cidr.IndexOf('/');
+        if (slash < 0) return null;
+        if (!TryParse(ip, out var ipv) || !TryParse(cidr.Substring(0, slash), out var basev)) return null;
+        if (!int.TryParse(cidr.Substring(slash + 1), out var bits) || bits < 0 || bits > 32) return null;
+        var mask = bits == 0 ? 0u : 0xFFFFFFFFu << (32 - bits);
+        return (ipv & mask) == (basev & mask);
+    }
+
+    public static bool? MaskedEqual(string a, string b, long? prefixArg)
+    {
+        var m = Masked(a, b, prefixArg, out var av, out var bv);
+        return m is null ? null : av == bv;
+    }
+
+    public static long? MaskedCompare(string a, string b, long? prefixArg)
+    {
+        var m = Masked(a, b, prefixArg, out var av, out var bv);
+        return m is null ? null : (av == bv ? 0L : av < bv ? -1L : 1L);
+    }
+
+    // Parse both operands (each may carry its own /prefix), mask to the smallest of the two suffixes and any explicit
+    // prefix argument, and hand back the masked values. Null when either operand is unparseable.
+    private static bool? Masked(string a, string b, long? prefixArg, out uint av, out uint bv)
+    {
+        av = 0; bv = 0;
+        if (string.IsNullOrEmpty(a) || string.IsNullOrEmpty(b)) return null;
+        var pa = SplitPrefix(a, out var aIp);
+        var pb = SplitPrefix(b, out var bIp);
+        if (!TryParse(aIp, out var a0) || !TryParse(bIp, out var b0)) return null;
+        var bits = Math.Min(Math.Min(pa, pb), (int)(prefixArg ?? 32));
+        if (bits < 0 || bits > 32) return null;
+        var mask = bits == 0 ? 0u : 0xFFFFFFFFu << (32 - bits);
+        av = a0 & mask; bv = b0 & mask;
+        return true;
+    }
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4Support.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/Ipv4Support.cs
@@ -37,6 +37,54 @@ internal static class Ipv4Support
         return (ipv & mask) == (basev & mask);
     }
 
+    public static string UintToDotted(uint v) =>
+        $"{(v >> 24) & 0xFF}.{(v >> 16) & 0xFF}.{(v >> 8) & 0xFF}.{v & 0xFF}";
+
+    // The network address of 'ip' masked to the smaller of its own /suffix and 'prefix' (default 32), as a uint.
+    // Null when the address is unparseable or the effective prefix is out of range.
+    public static uint? MaskedValue(string ip, long? prefix)
+    {
+        if (string.IsNullOrEmpty(ip)) return null;
+        var p = SplitPrefix(ip, out var addr);
+        if (!TryParse(addr, out var v)) return null;
+        var bits = (int)System.Math.Min(p, prefix ?? 32);
+        if (bits < 0 || bits > 32) return null;
+        var mask = bits == 0 ? 0u : 0xFFFFFFFFu << (32 - bits);
+        return v & mask;
+    }
+
+    // format_ipv4: the masked network address as dotted-quad.
+    public static string? FormatV4(string ip, long? prefix)
+    {
+        var v = MaskedValue(ip, prefix);
+        return v is null ? null : UintToDotted(v.Value);
+    }
+
+    // format_ipv4_mask: the masked network address in CIDR notation, using the effective prefix.
+    public static string? FormatV4Mask(string ip, long prefix)
+    {
+        if (prefix < 0 || prefix > 32) return null;
+        var p = SplitPrefix(ip, out _);
+        var bits = System.Math.Min(p, (int)prefix);
+        var v = MaskedValue(ip, prefix);
+        return v is null ? null : $"{UintToDotted(v.Value)}/{bits}";
+    }
+
+    // ipv4_netmask_suffix: the /suffix of a CIDR (32 when none present); null when the address is unparseable.
+    public static long? NetmaskSuffix(string ipRange)
+    {
+        if (string.IsNullOrEmpty(ipRange)) return null;
+        var p = SplitPrefix(ipRange, out var addr);
+        return TryParse(addr, out _) ? p : null;
+    }
+
+    // parse_ipv4_mask: the masked network address as a long.
+    public static long? ParseV4Mask(string ip, long prefix)
+    {
+        var v = MaskedValue(ip, prefix);
+        return v is null ? null : (long)v.Value;
+    }
+
     public static bool? MaskedEqual(string a, string b, long? prefixArg)
     {
         var m = Masked(a, b, prefixArg, out var av, out var bv);

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/ParseIpv4MaskFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/ParseIpv4MaskFunction.cs
@@ -1,0 +1,9 @@
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// parse_ipv4_mask(ip, prefix) -> the network address masked to the effective prefix as a long; null when the address is
+// unparseable or the prefix is out of range.
+[KustoImplementation(Keyword = "Functions.ParseIPV4Mask")]
+internal partial class ParseIpv4MaskFunction
+{
+    private static long? Impl(string ip, long prefix) => Ipv4Support.ParseV4Mask(ip, prefix);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/ParseUrlFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/ParseUrlFunction.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// parse_url(url) -> a dynamic object with the URL's Scheme, Host, Port, Path, Username, Password, Query Parameters and
+// Fragment components (empty strings / an empty object for absent parts), matching ADX.
+[KustoImplementation(Keyword = "Functions.ParseUrl")]
+internal partial class ParseUrlFunction
+{
+    private static JsonNode? Impl(string url) => UrlSupport.ParseUrl(url);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/ParseUrlQueryFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/ParseUrlQueryFunction.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// parse_urlquery(query) -> a dynamic object { "Query Parameters": { key: value, ... } } from a URL query string.
+[KustoImplementation(Keyword = "Functions.ParseUrlQuery")]
+internal partial class ParseUrlQueryFunction
+{
+    private static JsonNode? Impl(string query) => new JsonObject { ["Query Parameters"] = UrlSupport.ParseQuery(query) };
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/ParseUserAgentFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/ParseUserAgentFunction.cs
@@ -1,0 +1,98 @@
+//
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using Kusto.Language;
+using Kusto.Language.Symbols;
+using KustoLoco.Core.DataSource;
+using KustoLoco.Core.DataSource.Columns;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// parse_user_agent(user_agent, look_for) -> dynamic with the requested component(s): "browser" -> { Browser: {...} },
+// "os" -> { OperatingSystem: {...} }, "device" -> { Device: {...} }. look_for is one of those strings or a dynamic
+// array of them. Backed by the host-registered IUserAgentParser (via EvaluationContext.Providers); the engine ships no
+// user-agent database. No parser or a null user agent yields null.
+internal class ParseUserAgentFunctionImpl : IScalarFunctionImpl, IContextualScalarFunctionImpl
+{
+    public ScalarResult InvokeScalar(ScalarResult[] arguments) => InvokeScalar(arguments, default);
+
+    public ColumnarResult InvokeColumnar(ColumnarResult[] arguments) => InvokeColumnar(arguments, default);
+
+    public ScalarResult InvokeScalar(ScalarResult[] arguments, EvaluationContext context)
+    {
+        var parser = context.Providers?.Get<IUserAgentParser>();
+        return new ScalarResult(ScalarTypes.Dynamic,
+            Parse(parser, arguments[0].Value as string, arguments[1].Value));
+    }
+
+    public ColumnarResult InvokeColumnar(ColumnarResult[] arguments, EvaluationContext context)
+    {
+        var parser = context.Providers?.Get<IUserAgentParser>();
+        var rowCount = arguments[0].Column.RowCount;
+        var data = NullableSetBuilderOfJsonNode.CreateFixed(rowCount);
+        for (var row = 0; row < rowCount; row++)
+            data[row] = Parse(parser, arguments[0].Column.GetRawDataValue(row) as string,
+                arguments[1].Column.GetRawDataValue(row));
+        return new ColumnarResult(GenericColumnFactoryOfJsonNode.CreateFromDataSet(data.ToNullableSet()));
+    }
+
+    private static JsonNode? Parse(IUserAgentParser? parser, string? ua, object? lookFor)
+    {
+        if (parser is null || ua is null) return null;
+        var info = parser.Parse(ua);
+        var wanted = LookForSet(lookFor);
+        var obj = new JsonObject();
+        if (wanted.Contains("browser")) obj["Browser"] = Software(info.Browser, includePatchMinor: false);
+        if (wanted.Contains("os")) obj["OperatingSystem"] = Software(info.OperatingSystem, includePatchMinor: true);
+        if (wanted.Contains("device")) obj["Device"] = Device(info.Device);
+        return obj;
+    }
+
+    private static HashSet<string> LookForSet(object? lookFor)
+    {
+        var set = new HashSet<string>();
+        void Add(string? s) { if (!string.IsNullOrEmpty(s)) set.Add(Normalize(s)); }
+        switch (lookFor)
+        {
+            case string s: Add(s); break;
+            case JsonArray arr:
+                foreach (var el in arr) Add(el?.ToString());
+                break;
+            case JsonValue v when v.TryGetValue<string>(out var vs): Add(vs); break;
+        }
+        return set;
+    }
+
+    private static string Normalize(string s) => s.Trim().ToLowerInvariant() switch
+    {
+        "os" or "operatingsystem" or "operating_system" => "os",
+        _ => s.Trim().ToLowerInvariant()
+    };
+
+    private static JsonObject Software(UserAgentSoftware s, bool includePatchMinor)
+    {
+        var o = new JsonObject
+        {
+            ["Family"] = s.Family,
+            ["Major"] = s.Major,
+            ["Minor"] = s.Minor,
+            ["Patch"] = s.Patch,
+        };
+        if (includePatchMinor) o["PatchMinor"] = s.PatchMinor;
+        return o;
+    }
+
+    private static JsonObject Device(UserAgentDevice d) => new()
+    {
+        ["Family"] = d.Family,
+        ["Brand"] = d.Brand,
+        ["Model"] = d.Model,
+    };
+
+    internal static void Register(Dictionary<FunctionSymbol, ScalarFunctionInfo> functions) =>
+        functions.Add(Functions.ParseUserAgent, new ScalarFunctionInfo(
+            new ScalarOverloadInfo(new ParseUserAgentFunctionImpl(), ScalarTypes.Dynamic, ScalarTypes.String, ScalarTypes.String),
+            new ScalarOverloadInfo(new ParseUserAgentFunctionImpl(), ScalarTypes.Dynamic, ScalarTypes.String, ScalarTypes.Dynamic)));
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/SetHasElementFunction.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/SetHasElementFunction.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// set_has_element(set, value) -> true iff the dynamic array 'set' contains 'value' (by JSON value-equality); null when
+// 'set' is not a dynamic array. The value argument is polymorphic in ADX, so one overload per scalar type (the source
+// generator names each distinctly-suffixed *Impl method as its own overload).
+[KustoImplementation(Keyword = "Functions.SetHasElement")]
+internal partial class SetHasElementFunction
+{
+    private static bool? StringImpl(JsonNode set, string value) => DynamicSetSupport.Has(set, JsonValue.Create(value));
+    private static bool? LongImpl(JsonNode set, long value) => DynamicSetSupport.Has(set, JsonValue.Create(value));
+    private static bool? RealImpl(JsonNode set, double value) => DynamicSetSupport.Has(set, JsonValue.Create(value));
+    private static bool? BoolImpl(JsonNode set, bool value) => DynamicSetSupport.Has(set, JsonValue.Create(value));
+    private static bool? Impl(JsonNode set, JsonNode value) => DynamicSetSupport.Has(set, value);
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/SetOperationFunctions.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/SetOperationFunctions.cs
@@ -1,0 +1,126 @@
+//
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+using Kusto.Language;
+using Kusto.Language.Symbols;
+using KustoLoco.Core.DataSource;
+using KustoLoco.Core.DataSource.Columns;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// set_union / set_intersect / set_difference take an arbitrary number of dynamic arrays, so they are registered
+// manually (one overload per argument count) rather than via the source generator. All three deduplicate by JSON
+// value-equality (canonical JSON text) and preserve first-occurrence order, matching ADX.
+internal static class SetOpsSupport
+{
+    private const int MinSets = 2;
+    private const int MaxSets = 64;
+
+    private static IEnumerable<JsonNode?> Elements(object? value) =>
+        value is JsonArray a ? a : Enumerable.Empty<JsonNode?>();
+
+    private static string Key(JsonNode? node) => node?.ToJsonString() ?? "null";
+
+    public static JsonNode Union(IReadOnlyList<object?> values)
+    {
+        var seen = new HashSet<string>();
+        var result = new JsonArray();
+        foreach (var v in values)
+            foreach (var el in Elements(v))
+                if (seen.Add(Key(el)))
+                    result.Add(el?.DeepClone());
+        return result;
+    }
+
+    public static JsonNode Intersect(IReadOnlyList<object?> values)
+    {
+        var others = new List<HashSet<string>>();
+        for (var i = 1; i < values.Count; i++)
+            others.Add(Elements(values[i]).Select(Key).ToHashSet());
+        var seen = new HashSet<string>();
+        var result = new JsonArray();
+        foreach (var el in Elements(values.Count > 0 ? values[0] : null))
+        {
+            var key = Key(el);
+            if (!seen.Add(key)) continue;
+            if (others.All(s => s.Contains(key))) result.Add(el?.DeepClone());
+        }
+        return result;
+    }
+
+    public static JsonNode Difference(IReadOnlyList<object?> values)
+    {
+        var exclude = new HashSet<string>();
+        for (var i = 1; i < values.Count; i++)
+            foreach (var el in Elements(values[i]))
+                exclude.Add(Key(el));
+        var seen = new HashSet<string>();
+        var result = new JsonArray();
+        foreach (var el in Elements(values.Count > 0 ? values[0] : null))
+        {
+            var key = Key(el);
+            if (!seen.Add(key)) continue;
+            if (!exclude.Contains(key)) result.Add(el?.DeepClone());
+        }
+        return result;
+    }
+
+    public static void Register(Dictionary<FunctionSymbol, ScalarFunctionInfo> functions,
+        FunctionSymbol symbol, IScalarFunctionImpl impl)
+    {
+        var overloads = Enumerable.Range(MinSets, MaxSets - MinSets + 1)
+            .Select(n => new ScalarOverloadInfo(impl, ScalarTypes.Dynamic,
+                Enumerable.Repeat(ScalarTypes.Dynamic, n).ToArray()))
+            .ToArray();
+        functions.Add(symbol, new ScalarFunctionInfo(overloads));
+    }
+}
+
+internal class SetUnionFunctionImpl : IScalarFunctionImpl
+{
+    public ScalarResult InvokeScalar(ScalarResult[] arguments) =>
+        new(ScalarTypes.Dynamic, SetOpsSupport.Union(arguments.Select(a => a.Value).ToArray()));
+
+    public ColumnarResult InvokeColumnar(ColumnarResult[] arguments) => SetColumnar.Apply(arguments, SetOpsSupport.Union);
+
+    internal static void Register(Dictionary<FunctionSymbol, ScalarFunctionInfo> f) =>
+        SetOpsSupport.Register(f, Functions.SetUnion, new SetUnionFunctionImpl());
+}
+
+internal class SetIntersectFunctionImpl : IScalarFunctionImpl
+{
+    public ScalarResult InvokeScalar(ScalarResult[] arguments) =>
+        new(ScalarTypes.Dynamic, SetOpsSupport.Intersect(arguments.Select(a => a.Value).ToArray()));
+
+    public ColumnarResult InvokeColumnar(ColumnarResult[] arguments) => SetColumnar.Apply(arguments, SetOpsSupport.Intersect);
+
+    internal static void Register(Dictionary<FunctionSymbol, ScalarFunctionInfo> f) =>
+        SetOpsSupport.Register(f, Functions.SetIntersect, new SetIntersectFunctionImpl());
+}
+
+internal class SetDifferenceFunctionImpl : IScalarFunctionImpl
+{
+    public ScalarResult InvokeScalar(ScalarResult[] arguments) =>
+        new(ScalarTypes.Dynamic, SetOpsSupport.Difference(arguments.Select(a => a.Value).ToArray()));
+
+    public ColumnarResult InvokeColumnar(ColumnarResult[] arguments) => SetColumnar.Apply(arguments, SetOpsSupport.Difference);
+
+    internal static void Register(Dictionary<FunctionSymbol, ScalarFunctionInfo> f) =>
+        SetOpsSupport.Register(f, Functions.SetDifference, new SetDifferenceFunctionImpl());
+}
+
+internal static class SetColumnar
+{
+    public static ColumnarResult Apply(ColumnarResult[] arguments,
+        System.Func<IReadOnlyList<object?>, JsonNode> op)
+    {
+        var rowCount = arguments[0].Column.RowCount;
+        var data = NullableSetBuilderOfJsonNode.CreateFixed(rowCount);
+        for (var row = 0; row < rowCount; row++)
+            data[row] = op(arguments.Select(a => a.Column.GetRawDataValue(row)).ToArray());
+        return new ColumnarResult(GenericColumnFactoryOfJsonNode.CreateFromDataSet(data.ToNullableSet()));
+    }
+}

--- a/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/UrlSupport.cs
+++ b/libraries/KustoLoco.Core/Evaluation/BuiltIns/ScalarFunctions/UrlSupport.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Text.Json.Nodes;
+
+namespace KustoLoco.Core.Evaluation.BuiltIns.Impl;
+
+// Shared helpers for parse_url / parse_urlquery. Parsed literally (not via System.Uri, which would fill in default
+// ports and normalise the path) to match ADX's component breakdown.
+internal static class UrlSupport
+{
+    public static JsonNode ParseUrl(string? url)
+    {
+        var scheme = "";
+        var host = "";
+        var port = "";
+        var path = "";
+        var username = "";
+        var password = "";
+        var fragment = "";
+        var query = "";
+        var rest = url ?? "";
+
+        var schemeIdx = rest.IndexOf("://", StringComparison.Ordinal);
+        if (schemeIdx >= 0) { scheme = rest.Substring(0, schemeIdx); rest = rest.Substring(schemeIdx + 3); }
+
+        var hashIdx = rest.IndexOf('#');
+        if (hashIdx >= 0) { fragment = rest.Substring(hashIdx + 1); rest = rest.Substring(0, hashIdx); }
+
+        var qIdx = rest.IndexOf('?');
+        if (qIdx >= 0) { query = rest.Substring(qIdx + 1); rest = rest.Substring(0, qIdx); }
+
+        var slashIdx = rest.IndexOf('/');
+        var authority = rest;
+        if (slashIdx >= 0) { path = rest.Substring(slashIdx); authority = rest.Substring(0, slashIdx); }
+
+        var atIdx = authority.IndexOf('@');
+        if (atIdx >= 0)
+        {
+            var userinfo = authority.Substring(0, atIdx);
+            authority = authority.Substring(atIdx + 1);
+            var colon = userinfo.IndexOf(':');
+            if (colon >= 0) { username = userinfo.Substring(0, colon); password = userinfo.Substring(colon + 1); }
+            else username = userinfo;
+        }
+
+        var portColon = authority.LastIndexOf(':');
+        if (portColon >= 0) { host = authority.Substring(0, portColon); port = authority.Substring(portColon + 1); }
+        else host = authority;
+
+        return new JsonObject
+        {
+            ["Scheme"] = scheme,
+            ["Host"] = host,
+            ["Port"] = port,
+            ["Path"] = path,
+            ["Username"] = username,
+            ["Password"] = password,
+            ["Query Parameters"] = ParseQuery(query),
+            ["Fragment"] = fragment,
+        };
+    }
+
+    public static JsonObject ParseQuery(string? query)
+    {
+        var qp = new JsonObject();
+        if (string.IsNullOrEmpty(query)) return qp;
+        // a full URL or leading '?' is tolerated: keep only the query segment.
+        var q = query;
+        var qIdx = q.IndexOf('?');
+        if (qIdx >= 0) q = q.Substring(qIdx + 1);
+        var hashIdx = q.IndexOf('#');
+        if (hashIdx >= 0) q = q.Substring(0, hashIdx);
+        foreach (var pair in q.Split('&'))
+        {
+            if (pair.Length == 0) continue;
+            var eq = pair.IndexOf('=');
+            if (eq >= 0) qp[pair.Substring(0, eq)] = pair.Substring(eq + 1);
+            else qp[pair] = "";
+        }
+        return qp;
+    }
+}

--- a/libraries/KustoLoco.Core/Evaluation/Infra/EvaluationContext.cs
+++ b/libraries/KustoLoco.Core/Evaluation/Infra/EvaluationContext.cs
@@ -29,4 +29,8 @@ internal readonly record struct EvaluationContext
     public ITableChunk Chunk { get; init; }
 
     public TabularResult Left { get; init; }
+
+    // Host-registered providers for data-backed scalar functions, threaded from the engine. Null when none are
+    // registered; functions treat that as "no data" and return null.
+    public IProviderRegistry? Providers { get; init; }
 }

--- a/libraries/KustoLoco.Core/Evaluation/Providers/Providers.cs
+++ b/libraries/KustoLoco.Core/Evaluation/Providers/Providers.cs
@@ -42,3 +42,27 @@ public sealed record GeoIpInfo(
     string? City = null,
     double? Latitude = null,
     double? Longitude = null);
+
+// parse_user_agent data provider. The engine ships no user-agent database; a faithful implementation (e.g. one backed
+// by the uap-core dataset) lives in a companion package and is registered by the host.
+public interface IUserAgentParser
+{
+    UserAgentInfo Parse(string userAgent);
+}
+
+public sealed record UserAgentInfo(
+    UserAgentSoftware Browser,
+    UserAgentSoftware OperatingSystem,
+    UserAgentDevice Device);
+
+public sealed record UserAgentSoftware(
+    string? Family = null,
+    string? Major = null,
+    string? Minor = null,
+    string? Patch = null,
+    string? PatchMinor = null);
+
+public sealed record UserAgentDevice(
+    string? Family = null,
+    string? Brand = null,
+    string? Model = null);

--- a/libraries/KustoLoco.Core/Evaluation/Providers/Providers.cs
+++ b/libraries/KustoLoco.Core/Evaluation/Providers/Providers.cs
@@ -1,0 +1,44 @@
+//
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+
+namespace KustoLoco.Core;
+
+// A per-query registry of host-supplied providers that data-backed scalar functions read at evaluation time. It is
+// registered on the engine and threaded through the EvaluationContext. When a function's provider is absent the
+// function returns null (inert) rather than failing, so queries that reference it still run.
+public interface IProviderRegistry
+{
+    T? Get<T>() where T : class;
+}
+
+public sealed class ProviderRegistry : IProviderRegistry
+{
+    private readonly Dictionary<Type, object> _providers = new();
+
+    public ProviderRegistry Set<T>(T provider) where T : class
+    {
+        _providers[typeof(T)] = provider;
+        return this;
+    }
+
+    public T? Get<T>() where T : class =>
+        _providers.TryGetValue(typeof(T), out var p) ? (T)p : null;
+}
+
+// geo_info_from_ip_address data provider. The engine ships no geo database (licences vary and not every consumer wants
+// the dependency); the host supplies the IP -> geo lookup. Returning null for an address yields a null function result.
+public interface IGeoIpProvider
+{
+    GeoIpInfo? Lookup(IPAddress address);
+}
+
+public sealed record GeoIpInfo(
+    string? Country = null,
+    string? State = null,
+    string? City = null,
+    double? Latitude = null,
+    double? Longitude = null);

--- a/libraries/KustoLoco.Core/Evaluation/Providers/Providers.cs
+++ b/libraries/KustoLoco.Core/Evaluation/Providers/Providers.cs
@@ -43,23 +43,23 @@ public sealed record GeoIpInfo(
     double? Latitude = null,
     double? Longitude = null);
 
-// externaldata resolver. The engine never performs network access itself: it hands the declared schema, the requested
-// URIs and the format to a host-registered resolver, which fetches and returns the rows. No resolver registered means
-// externaldata is unavailable (fail-closed) - the host must opt in, and is where URL-allowlisting / SSRF protection /
-// authentication live. Returning the rows column-major matches how the engine builds a table.
+/// <summary>
+/// Resolves an <c>externaldata</c> URI to delimited rows (already split into string cells). The engine calls this
+/// once per URI in an <c>externaldata (schema) [ "uri", ... ] with (format=...)</c> expression, then types each cell
+/// per the declared schema and materializes a table — the same path a <c>datatable</c> literal takes.
+/// </summary>
+/// <remarks>
+/// The implementation owns ALL fetch policy: which URI schemes are allowed, size and time bounds, authentication and
+/// caching. This mirrors <see cref="IKustoQueryContextTableLoader"/>, where the host likewise supplies the data and
+/// owns the policy; the engine supplies <see cref="DelimitedTextParser"/> so the declared format need not be
+/// reimplemented. It MUST throw on a fetch or parse failure so the query fails loudly — returning an empty set would
+/// silently turn a broken feed into a no-match. The engine performs NO network access of its own and registers no
+/// default resolver, so <c>externaldata</c> is unavailable until a host opts in.
+/// </remarks>
 public interface IExternalDataResolver
 {
-    // Resolve the data for one externaldata expression. 'columnTypes' are the declared column .NET types (in schema
-    // order); the implementation returns one object?[] per column, all of equal length. Return null to yield an empty
-    // table. Throw to fail the query (e.g. a disallowed URI).
-    IReadOnlyList<object?[]>? Resolve(ExternalDataRequest request);
+    IReadOnlyList<IReadOnlyList<string>> ResolveRows(string uri, string format);
 }
-
-public sealed record ExternalDataRequest(
-    IReadOnlyList<string> Uris,
-    string Format,
-    IReadOnlyList<string> ColumnNames,
-    IReadOnlyList<System.Type> ColumnTypes);
 
 // parse_user_agent data provider. The engine ships no user-agent database; a faithful implementation (e.g. one backed
 // by the uap-core dataset) lives in a companion package and is registered by the host.

--- a/libraries/KustoLoco.Core/Evaluation/Providers/Providers.cs
+++ b/libraries/KustoLoco.Core/Evaluation/Providers/Providers.cs
@@ -43,6 +43,24 @@ public sealed record GeoIpInfo(
     double? Latitude = null,
     double? Longitude = null);
 
+// externaldata resolver. The engine never performs network access itself: it hands the declared schema, the requested
+// URIs and the format to a host-registered resolver, which fetches and returns the rows. No resolver registered means
+// externaldata is unavailable (fail-closed) - the host must opt in, and is where URL-allowlisting / SSRF protection /
+// authentication live. Returning the rows column-major matches how the engine builds a table.
+public interface IExternalDataResolver
+{
+    // Resolve the data for one externaldata expression. 'columnTypes' are the declared column .NET types (in schema
+    // order); the implementation returns one object?[] per column, all of equal length. Return null to yield an empty
+    // table. Throw to fail the query (e.g. a disallowed URI).
+    IReadOnlyList<object?[]>? Resolve(ExternalDataRequest request);
+}
+
+public sealed record ExternalDataRequest(
+    IReadOnlyList<string> Uris,
+    string Format,
+    IReadOnlyList<string> ColumnNames,
+    IReadOnlyList<System.Type> ColumnTypes);
+
 // parse_user_agent data provider. The engine ships no user-agent database; a faithful implementation (e.g. one backed
 // by the uap-core dataset) lives in a companion package and is registered by the host.
 public interface IUserAgentParser

--- a/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.Expressions.ExternalData.cs
+++ b/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.Expressions.ExternalData.cs
@@ -1,0 +1,36 @@
+//
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using Kusto.Language.Symbols;
+using KustoLoco.Core.DataSource;
+using KustoLoco.Core.DataSource.Columns;
+using KustoLoco.Core.InternalRepresentation.Nodes.Expressions;
+using KustoLoco.Core.Util;
+
+namespace KustoLoco.Core.Evaluation;
+
+internal partial class TreeEvaluator
+{
+    public override EvaluationResult VisitExternalDataExpression(IRExternalDataExpression node, EvaluationContext context)
+    {
+        var schema = (TableSymbol)node.ResultType;
+        var resolver = context.Providers?.Get<IExternalDataResolver>();
+
+        var columnNames = schema.Columns.Select(c => c.Name).ToArray();
+        var columnTypes = schema.Columns.Select(c => TypeMapping.UnderlyingTypeForSymbol(c.Type)).ToArray();
+
+        // No resolver registered => fail-closed (empty table); the host must opt in to fetch external data.
+        var data = resolver?.Resolve(new ExternalDataRequest(node.Uris, node.Format, columnNames, columnTypes));
+
+        var columns = new BaseColumn[schema.Columns.Count];
+        for (var j = 0; j < schema.Columns.Count; j++)
+        {
+            var columnData = data != null && j < data.Count ? data[j] : Array.Empty<object?>();
+            columns[j] = ColumnHelpers.CreateFromObjectArray(columnData, schema.Columns[j].Type);
+        }
+
+        return TabularResult.CreateUnvisualized(new InMemoryTableSource(schema, columns));
+    }
+}

--- a/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.Expressions.ExternalData.cs
+++ b/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.Expressions.ExternalData.cs
@@ -2,7 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Text.Json.Nodes;
 using Kusto.Language.Symbols;
 using KustoLoco.Core.DataSource;
 using KustoLoco.Core.DataSource.Columns;
@@ -16,21 +19,64 @@ internal partial class TreeEvaluator
     public override EvaluationResult VisitExternalDataExpression(IRExternalDataExpression node, EvaluationContext context)
     {
         var schema = (TableSymbol)node.ResultType;
-        var resolver = context.Providers?.Get<IExternalDataResolver>();
+        var resolver = context.Providers?.Get<IExternalDataResolver>()
+            // The engine performs no I/O of its own, so there is nothing sane to default to: fail LOUD rather than
+            // yield an empty table, which would silently turn an unreachable list into a no-match.
+            ?? throw new InvalidOperationException(
+                "externaldata requires a host-provided IExternalDataResolver (register one with " +
+                "KustoQueryContext.SetExternalDataResolver); the engine performs no network or file access itself.");
 
-        var columnNames = schema.Columns.Select(c => c.Name).ToArray();
-        var columnTypes = schema.Columns.Select(c => TypeMapping.UnderlyingTypeForSymbol(c.Type)).ToArray();
-
-        // No resolver registered => fail-closed (empty table); the host must opt in to fetch external data.
-        var data = resolver?.Resolve(new ExternalDataRequest(node.Uris, node.Format, columnNames, columnTypes));
+        // The host resolves and splits each URI; the engine types the cells per the declared schema.
+        var cells = new List<IReadOnlyList<string>>();
+        foreach (var uri in node.Uris)
+            cells.AddRange(resolver.ResolveRows(uri, node.Format));
 
         var columns = new BaseColumn[schema.Columns.Count];
         for (var j = 0; j < schema.Columns.Count; j++)
         {
-            var columnData = data != null && j < data.Count ? data[j] : Array.Empty<object?>();
-            columns[j] = ColumnHelpers.CreateFromObjectArray(columnData, schema.Columns[j].Type);
+            var type = schema.Columns[j].Type;
+            var data = new object?[cells.Count];
+            for (var i = 0; i < cells.Count; i++)
+                data[i] = j < cells[i].Count ? ConvertCell(cells[i][j], type) : null;
+            columns[j] = ColumnHelpers.CreateFromObjectArray(data, type);
         }
 
         return TabularResult.CreateUnvisualized(new InMemoryTableSource(schema, columns));
+    }
+
+    /// <summary>Type one text cell per its declared column type. An unparseable cell is null rather than an error:
+    /// a single malformed value must not fail the whole query, matching how a missing value behaves elsewhere.</summary>
+    private static object? ConvertCell(string? text, TypeSymbol type)
+    {
+        if (text is null) return null;
+        var trimmed = text.Trim();
+        if (type == ScalarTypes.String) return text;
+        if (trimmed.Length == 0) return null;
+
+        if (type == ScalarTypes.Bool)
+            return bool.TryParse(trimmed, out var b) ? b
+                : long.TryParse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture, out var bi) ? bi != 0
+                : null;
+        if (type == ScalarTypes.Int)
+            return int.TryParse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture, out var i) ? i : null;
+        if (type == ScalarTypes.Long)
+            return long.TryParse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture, out var l) ? l : null;
+        if (type == ScalarTypes.Real)
+            return double.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out var d) ? d : null;
+        if (type == ScalarTypes.Decimal)
+            return decimal.TryParse(trimmed, NumberStyles.Number, CultureInfo.InvariantCulture, out var m) ? m : null;
+        if (type == ScalarTypes.DateTime)
+            return DateTime.TryParse(trimmed, CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var dt) ? dt : null;
+        if (type == ScalarTypes.TimeSpan)
+            return TimeSpan.TryParse(trimmed, CultureInfo.InvariantCulture, out var ts) ? ts : null;
+        if (type == ScalarTypes.Guid)
+            return Guid.TryParse(trimmed, out var g) ? g : null;
+        if (type == ScalarTypes.Dynamic)
+        {
+            try { return JsonNode.Parse(trimmed); }
+            catch (System.Text.Json.JsonException) { return JsonValue.Create(text); }
+        }
+        return text;
     }
 }

--- a/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.Expressions.FunctionCalls.cs
+++ b/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.Expressions.FunctionCalls.cs
@@ -56,7 +56,7 @@ internal partial class TreeEvaluator
             arguments = new[] { dummy }.Concat(arguments).ToArray();
         }
 
-        return impl(arguments);
+        return impl(arguments, context);
     }
 
     public override EvaluationResult VisitBuiltInWindowFunctionCall(IRBuiltInWindowFunctionCallNode node,
@@ -134,7 +134,7 @@ internal partial class TreeEvaluator
             functionCallScope.AddSymbol(node.ParamSymbols[i], argValue);
         }
 
-        return node.ExpandedBody.Accept(this, new EvaluationContext(functionCallScope));
+        return node.ExpandedBody.Accept(this, new EvaluationContext(functionCallScope) { Providers = context.Providers });
     }
 
     public override EvaluationResult VisitFunctionBody(IRFunctionBodyNode node, EvaluationContext context)

--- a/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.Expressions.Operators.cs
+++ b/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.Expressions.Operators.cs
@@ -17,7 +17,7 @@ internal partial class TreeEvaluator
 
         var val = node.Expression.Accept(this, context);
         var arguments = new[] { val };
-        return impl(arguments);
+        return impl(arguments, context);
     }
 
     public override EvaluationResult VisitBinaryExpression(IRBinaryExpressionNode node, EvaluationContext context)
@@ -34,6 +34,6 @@ internal partial class TreeEvaluator
         var leftVal = node.Left.Accept(this, context);
         var rightVal = node.Right.Accept(this, context);
         var arguments = new[] { leftVal, rightVal };
-        return impl(arguments);
+        return impl(arguments, context);
     }
 }

--- a/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.Ipv4Lookup.cs
+++ b/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.Ipv4Lookup.cs
@@ -1,0 +1,77 @@
+//
+// Licensed under the MIT License.
+
+using System.Linq;
+using Kusto.Language.Symbols;
+using KustoLoco.Core.DataSource;
+using KustoLoco.Core.Evaluation.BuiltIns.Impl;
+using KustoLoco.Core.InternalRepresentation.Nodes.Expressions.QueryOperators;
+using KustoLoco.Core.Util;
+
+namespace KustoLoco.Core.Evaluation;
+
+internal partial class TreeEvaluator
+{
+    public override EvaluationResult VisitIpv4LookupOperator(IRIpv4LookupOperatorNode node, EvaluationContext context)
+    {
+        var source = context.Left.Value;
+        var sourceSchema = source.Type;
+        var resultSchema = (TableSymbol)node.ResultType;
+
+        var srcChunk = ChunkHelpers.Reassemble(source.GetData().ToArray());
+        var sourceIpColumn = ((ColumnarResult)node.SourceIp.Accept(this, context with { Chunk = srcChunk })).Column;
+
+        // Evaluate and materialise the lookup table.
+        var lookup = ((TabularResult)node.LookupTable.Accept(this, context)).Value;
+        var lookupSchema = lookup.Type;
+        var lookupChunk = ChunkHelpers.Reassemble(lookup.GetData().ToArray());
+        var lookupIpIdx = IndexOf(lookupSchema, node.LookupIpColumn);
+
+        var outBuilders = ColumnHelpers.CreateBuildersForTable(resultSchema);
+
+        for (var sr = 0; sr < srcChunk.RowCount; sr++)
+        {
+            var ip = sourceIpColumn.GetRawDataValue(sr)?.ToString();
+            var matched = false;
+            if (ip != null && lookupIpIdx >= 0)
+                for (var lr = 0; lr < lookupChunk.RowCount; lr++)
+                {
+                    var cidr = lookupChunk.Columns[lookupIpIdx].GetRawDataValue(lr)?.ToString();
+                    if (cidr != null && Ipv4Support.InRange(ip, cidr) == true)
+                    {
+                        AppendJoinedRow(outBuilders, resultSchema, sourceSchema, lookupSchema, srcChunk, sr, lookupChunk, lr);
+                        matched = true;
+                    }
+                }
+
+            if (!matched && node.ReturnUnmatched)
+                AppendJoinedRow(outBuilders, resultSchema, sourceSchema, lookupSchema, srcChunk, sr, lookupChunk, -1);
+        }
+
+        var columns = outBuilders.Select(b => b.ToColumn()).ToArray();
+        return TabularResult.CreateUnvisualized(new InMemoryTableSource(resultSchema, columns));
+    }
+
+    private static void AppendJoinedRow(
+        BaseColumnBuilder[] builders,
+        TableSymbol resultSchema, TableSymbol sourceSchema, TableSymbol lookupSchema,
+        ITableChunk srcChunk, int sourceRow, ITableChunk lookupChunk, int lookupRow)
+    {
+        for (var col = 0; col < resultSchema.Columns.Count; col++)
+        {
+            var name = resultSchema.Columns[col].Name;
+            var srcIdx = IndexOf(sourceSchema, name);
+            if (srcIdx >= 0)
+            {
+                builders[col].Add(srcChunk.Columns[srcIdx].GetRawDataValue(sourceRow));
+            }
+            else
+            {
+                var lupIdx = IndexOf(lookupSchema, name);
+                builders[col].Add(lookupRow >= 0 && lupIdx >= 0
+                    ? lookupChunk.Columns[lupIdx].GetRawDataValue(lookupRow)
+                    : null);
+            }
+        }
+    }
+}

--- a/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.Ipv4Lookup.cs
+++ b/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.Ipv4Lookup.cs
@@ -29,6 +29,12 @@ internal partial class TreeEvaluator
 
         var outBuilders = ColumnHelpers.CreateBuildersForTable(resultSchema);
 
+        // ExtraKeys must exist in BOTH tables and match by equality, narrowing the IPv4 match (like extra join keys).
+        var extraKeyIndices = node.ExtraKeys
+            .Select(name => (Source: IndexOf(sourceSchema, name), Lookup: IndexOf(lookupSchema, name)))
+            .Where(pair => pair.Source >= 0 && pair.Lookup >= 0)
+            .ToArray();
+
         for (var sr = 0; sr < srcChunk.RowCount; sr++)
         {
             var ip = sourceIpColumn.GetRawDataValue(sr)?.ToString();
@@ -37,11 +43,12 @@ internal partial class TreeEvaluator
                 for (var lr = 0; lr < lookupChunk.RowCount; lr++)
                 {
                     var cidr = lookupChunk.Columns[lookupIpIdx].GetRawDataValue(lr)?.ToString();
-                    if (cidr != null && Ipv4Support.InRange(ip, cidr) == true)
-                    {
-                        AppendJoinedRow(outBuilders, resultSchema, sourceSchema, lookupSchema, srcChunk, sr, lookupChunk, lr);
-                        matched = true;
-                    }
+                    if (cidr == null || Ipv4Support.InRange(ip, cidr) != true)
+                        continue;
+                    if (!ExtraKeysMatch(extraKeyIndices, srcChunk, sr, lookupChunk, lr))
+                        continue;
+                    AppendJoinedRow(outBuilders, resultSchema, sourceSchema, lookupSchema, srcChunk, sr, lookupChunk, lr);
+                    matched = true;
                 }
 
             if (!matched && node.ReturnUnmatched)
@@ -50,6 +57,16 @@ internal partial class TreeEvaluator
 
         var columns = outBuilders.Select(b => b.ToColumn()).ToArray();
         return TabularResult.CreateUnvisualized(new InMemoryTableSource(resultSchema, columns));
+    }
+
+    private static bool ExtraKeysMatch((int Source, int Lookup)[] keys, ITableChunk srcChunk, int sourceRow,
+        ITableChunk lookupChunk, int lookupRow)
+    {
+        foreach (var (source, lookup) in keys)
+            if (!Equals(srcChunk.Columns[source].GetRawDataValue(sourceRow),
+                        lookupChunk.Columns[lookup].GetRawDataValue(lookupRow)))
+                return false;
+        return true;
     }
 
     private static void AppendJoinedRow(

--- a/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.Join.cs
+++ b/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.Join.cs
@@ -51,7 +51,7 @@ internal partial class TreeEvaluator
 
         public IEnumerable<ITableChunk> GetData()
         {
-            var rightContext = new EvaluationContext(_context.Scope);
+            var rightContext = new EvaluationContext(_context.Scope) { Providers = _context.Providers };
             var rightResult = _rightExpression.Accept(_owner, rightContext);
             if (rightResult == EvaluationResult.Null || !rightResult.IsTabular)
                 throw new InvalidOperationException(
@@ -83,7 +83,7 @@ internal partial class TreeEvaluator
 
             var onValuesColumns = new List<BaseColumn>(_onClauses.Count);
 
-            var chunkContext = new EvaluationContext(_context.Scope, chunk);
+            var chunkContext = new EvaluationContext(_context.Scope, chunk) { Providers = _context.Providers };
             foreach (var onExpression in onExpressions)
             {
                 var onExpressionResult = (ColumnarResult?)onExpression.Accept(_owner, chunkContext);

--- a/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.MakeSeries.cs
+++ b/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.MakeSeries.cs
@@ -30,9 +30,33 @@ internal partial class TreeEvaluator
         var fromVal = ((ScalarResult)node.From.Accept(this, chunkContext)).Value;
         var toVal = ((ScalarResult)node.To.Accept(this, chunkContext)).Value;
         var stepVal = ((ScalarResult)node.Step.Accept(this, chunkContext)).Value;
-        var from = ToDouble(fromVal);
-        var step = ToDouble(stepVal);
-        var binCount = step != 0 ? (int)Math.Floor((ToDouble(toVal) - from) / step) : 0;
+
+        // KQL make-series bins the axis into [from, to) buckets of width step (bin_at semantics): 'to' is
+        // NON-inclusive and the number of points is the count of start + i*step values strictly below 'to'. Temporal
+        // axes are computed in exact integer ticks — datetime ticks (~6.3e17) exceed double's 2^53 exact-integer
+        // range, so doing the arithmetic in double would drift the axis and mis-bin rows.
+        var axisIsDateTime = fromVal is DateTime;
+        var axisIsTimeSpan = fromVal is TimeSpan;
+        var temporal = axisIsDateTime || axisIsTimeSpan;
+
+        long fromTicks = 0, stepTicks = 0;
+        double fromD = 0, stepD = 0;
+        int binCount;
+        if (temporal)
+        {
+            fromTicks = ToTicks(fromVal);
+            stepTicks = ToTicks(stepVal);
+            var span = ToTicks(toVal) - fromTicks;
+            binCount = stepTicks > 0 && span > 0 ? (int)((span + stepTicks - 1) / stepTicks) : 0; // ceil, exclusive end
+        }
+        else
+        {
+            fromD = ToDouble(fromVal);
+            stepD = ToDouble(stepVal);
+            var span = ToDouble(toVal) - fromD;
+            // Subtract a tiny epsilon so an exact multiple isn't rounded up by floating-point error.
+            binCount = stepD > 0 && span > 0 ? (int)Math.Ceiling(span / stepD - 1e-9) : 0;
+        }
         if (binCount < 0) binCount = 0;
 
         // Axis + by-columns evaluated columnar over the whole chunk.
@@ -54,16 +78,23 @@ internal partial class TreeEvaluator
                 groupOrder.Add(key);
             }
 
-            var axisD = ToDouble(axisColumn.GetRawDataValue(r));
-            if (step == 0) continue;
-            var bin = (int)Math.Floor((axisD - from) / step);
+            int bin;
+            if (temporal)
+            {
+                var t = ToTicks(axisColumn.GetRawDataValue(r));
+                bin = stepTicks > 0 && t >= fromTicks ? (int)((t - fromTicks) / stepTicks) : -1;
+            }
+            else
+            {
+                var axisD = ToDouble(axisColumn.GetRawDataValue(r));
+                bin = stepD > 0 ? (int)Math.Floor((axisD - fromD) / stepD) : -1;
+            }
             if (bin >= 0 && bin < binCount) state.BinRows[bin].Add(r);
         }
 
         var outBuilders = ColumnHelpers.CreateBuildersForTable(resultSchema);
-        // Column layout of the result: [by columns..., axis series, aggregate series...].
+        // Column layout of the result: [by columns..., aggregate series..., axis series].
         var byCount = node.ByColumns.Count;
-        var axisIsDateTime = fromVal is DateTime;
 
         foreach (var key in groupOrder)
         {
@@ -73,27 +104,19 @@ internal partial class TreeEvaluator
             // by columns
             for (var b = 0; b < byCount; b++) outBuilders[outCol++].Add(key.Values[b]);
 
-            // axis series: from + i*step for each bin
-            var axisArray = new JsonArray();
-            for (var i = 0; i < binCount; i++)
-            {
-                var pointTicks = from + i * step;
-                axisArray.Add(axisIsDateTime
-                    ? JsonValue.Create(new DateTime((long)pointTicks, DateTimeKind.Utc).ToString("o"))
-                    : JsonValue.Create(pointTicks));
-            }
-            outBuilders[outCol++].Add(axisArray);
-
-            // one series per aggregate: aggregate the rows in each bin, gap-fill empties with the default.
+            // one series per aggregate: aggregate the rows in each bin, gap-fill empty bins with the default.
             for (var a = 0; a < node.Aggregations.Count; a++)
             {
+                // ADX fills empty bins with the per-aggregate default; when no 'default=' clause is written the default
+                // is 0 (typed to the aggregate's result), not null. An explicit 'default=<null>' still fills with null.
+                var fill = node.DefaultProvided[a] ? node.Defaults[a] : DefaultZero(node.Aggregations[a].ResultType);
                 var series = new JsonArray();
                 for (var i = 0; i < binCount; i++)
                 {
                     var rows = state.BinRows[i];
                     if (rows.Count == 0)
                     {
-                        series.Add(ToJson(node.Defaults[a]));
+                        series.Add(ToJson(fill));
                         continue;
                     }
 
@@ -105,11 +128,42 @@ internal partial class TreeEvaluator
                 }
                 outBuilders[outCol++].Add(series);
             }
+
+            // axis series: from + i*step for each bin (exact in the axis's native type).
+            var axisArray = new JsonArray();
+            for (var i = 0; i < binCount; i++)
+            {
+                if (axisIsDateTime)
+                    axisArray.Add(JsonValue.Create(
+                        new DateTime(fromTicks + (long)i * stepTicks, DateTimeKind.Utc).ToString("o")));
+                else if (axisIsTimeSpan)
+                    axisArray.Add(JsonValue.Create(fromTicks + (long)i * stepTicks));
+                else
+                    axisArray.Add(JsonValue.Create(fromD + i * stepD));
+            }
+            outBuilders[outCol++].Add(axisArray);
         }
 
         var outColumns = outBuilders.Select(b => b.ToColumn()).ToArray();
         return TabularResult.CreateUnvisualized(new InMemoryTableSource(resultSchema, outColumns));
     }
+
+    private static long ToTicks(object? v) => v switch
+    {
+        DateTime dt => dt.Ticks,
+        TimeSpan ts => ts.Ticks,
+        long l => l,
+        int i => i,
+        double d => (long)d,
+        decimal m => (long)m,
+        _ => 0
+    };
+
+    private static object DefaultZero(TypeSymbol t) =>
+        t == ScalarTypes.Real ? 0.0 :
+        t == ScalarTypes.Decimal ? 0m :
+        t == ScalarTypes.Int ? 0 :
+        0L;
 
     private static double ToDouble(object? v) => v switch
     {

--- a/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.MakeSeries.cs
+++ b/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.MakeSeries.cs
@@ -156,7 +156,9 @@ internal partial class TreeEvaluator
 
     private static long ToTicks(object? v) => v switch
     {
-        DateTime dt => dt.Ticks,
+        // A datetime is compared and binned on the UTC instant it denotes: a local-kind value carries an offset
+        // that would otherwise shift it against UTC axis data and drop every row into no bin at all.
+        DateTime dt => (dt.Kind == DateTimeKind.Local ? dt.ToUniversalTime() : dt).Ticks,
         TimeSpan ts => ts.Ticks,
         long l => l,
         int i => i,
@@ -173,7 +175,9 @@ internal partial class TreeEvaluator
 
     private static double ToDouble(object? v) => v switch
     {
-        DateTime dt => dt.Ticks,
+        // A datetime is compared and binned on the UTC instant it denotes: a local-kind value carries an offset
+        // that would otherwise shift it against UTC axis data and drop every row into no bin at all.
+        DateTime dt => (dt.Kind == DateTimeKind.Local ? dt.ToUniversalTime() : dt).Ticks,
         TimeSpan ts => ts.Ticks,
         long l => l,
         int i => i,

--- a/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.MakeSeries.cs
+++ b/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.MakeSeries.cs
@@ -39,6 +39,8 @@ internal partial class TreeEvaluator
         var axisIsTimeSpan = fromVal is TimeSpan;
         var temporal = axisIsDateTime || axisIsTimeSpan;
 
+        // An inclusive stop (the 'in range(..)' syntax) admits the point at 'to': count = floor(span/step)+1. A
+        // non-inclusive end ('from .. to ..') stops strictly below 'to': count = ceil(span/step).
         long fromTicks = 0, stepTicks = 0;
         double fromD = 0, stepD = 0;
         int binCount;
@@ -47,15 +49,19 @@ internal partial class TreeEvaluator
             fromTicks = ToTicks(fromVal);
             stepTicks = ToTicks(stepVal);
             var span = ToTicks(toVal) - fromTicks;
-            binCount = stepTicks > 0 && span > 0 ? (int)((span + stepTicks - 1) / stepTicks) : 0; // ceil, exclusive end
+            if (stepTicks <= 0) binCount = 0;
+            else if (node.StopInclusive) binCount = span >= 0 ? (int)(span / stepTicks) + 1 : 0;
+            else binCount = span > 0 ? (int)((span + stepTicks - 1) / stepTicks) : 0;
         }
         else
         {
             fromD = ToDouble(fromVal);
             stepD = ToDouble(stepVal);
             var span = ToDouble(toVal) - fromD;
-            // Subtract a tiny epsilon so an exact multiple isn't rounded up by floating-point error.
-            binCount = stepD > 0 && span > 0 ? (int)Math.Ceiling(span / stepD - 1e-9) : 0;
+            // The +/-1e-9 keeps an exact multiple from being mis-rounded by floating-point error.
+            if (stepD <= 0) binCount = 0;
+            else if (node.StopInclusive) binCount = span >= 0 ? (int)Math.Floor(span / stepD + 1e-9) + 1 : 0;
+            else binCount = span > 0 ? (int)Math.Ceiling(span / stepD - 1e-9) : 0;
         }
         if (binCount < 0) binCount = 0;
 

--- a/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.MakeSeries.cs
+++ b/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.MakeSeries.cs
@@ -1,0 +1,172 @@
+//
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text.Json.Nodes;
+using Kusto.Language.Symbols;
+using KustoLoco.Core.DataSource;
+using KustoLoco.Core.DataSource.Columns;
+using KustoLoco.Core.InternalRepresentation.Nodes.Expressions.QueryOperators;
+using KustoLoco.Core.Util;
+
+namespace KustoLoco.Core.Evaluation;
+
+internal partial class TreeEvaluator
+{
+    public override EvaluationResult VisitMakeSeriesOperator(IRMakeSeriesOperatorNode node, EvaluationContext context)
+    {
+        var input = context.Left.Value;
+        var resultSchema = (TableSymbol)node.ResultType;
+
+        // Reassemble the input into a single chunk so we can index rows freely.
+        var chunk = ChunkHelpers.Reassemble(input.GetData().ToArray());
+        var rowCount = chunk.RowCount;
+        var chunkContext = context with { Chunk = chunk };
+
+        // Range: from / to / step are constant scalars.
+        var fromVal = ((ScalarResult)node.From.Accept(this, chunkContext)).Value;
+        var toVal = ((ScalarResult)node.To.Accept(this, chunkContext)).Value;
+        var stepVal = ((ScalarResult)node.Step.Accept(this, chunkContext)).Value;
+        var from = ToDouble(fromVal);
+        var step = ToDouble(stepVal);
+        var binCount = step != 0 ? (int)Math.Floor((ToDouble(toVal) - from) / step) : 0;
+        if (binCount < 0) binCount = 0;
+
+        // Axis + by-columns evaluated columnar over the whole chunk.
+        var axisColumn = ((ColumnarResult)node.Axis.Accept(this, chunkContext)).Column;
+        var byColumns = node.ByColumns
+            .Select(b => ((ColumnarResult)b.Accept(this, chunkContext)).Column)
+            .ToArray();
+
+        // Group rows by the by-values, and within a group index them by bin.
+        var groups = new Dictionary<GroupKey, GroupState>();
+        var groupOrder = new List<GroupKey>();
+        for (var r = 0; r < rowCount; r++)
+        {
+            var key = new GroupKey(byColumns.Select(c => c.GetRawDataValue(r)).ToArray());
+            if (!groups.TryGetValue(key, out var state))
+            {
+                state = new GroupState(binCount);
+                groups[key] = state;
+                groupOrder.Add(key);
+            }
+
+            var axisD = ToDouble(axisColumn.GetRawDataValue(r));
+            if (step == 0) continue;
+            var bin = (int)Math.Floor((axisD - from) / step);
+            if (bin >= 0 && bin < binCount) state.BinRows[bin].Add(r);
+        }
+
+        var outBuilders = ColumnHelpers.CreateBuildersForTable(resultSchema);
+        // Column layout of the result: [by columns..., axis series, aggregate series...].
+        var byCount = node.ByColumns.Count;
+        var axisIsDateTime = fromVal is DateTime;
+
+        foreach (var key in groupOrder)
+        {
+            var state = groups[key];
+            var outCol = 0;
+
+            // by columns
+            for (var b = 0; b < byCount; b++) outBuilders[outCol++].Add(key.Values[b]);
+
+            // axis series: from + i*step for each bin
+            var axisArray = new JsonArray();
+            for (var i = 0; i < binCount; i++)
+            {
+                var pointTicks = from + i * step;
+                axisArray.Add(axisIsDateTime
+                    ? JsonValue.Create(new DateTime((long)pointTicks, DateTimeKind.Utc).ToString("o"))
+                    : JsonValue.Create(pointTicks));
+            }
+            outBuilders[outCol++].Add(axisArray);
+
+            // one series per aggregate: aggregate the rows in each bin, gap-fill empties with the default.
+            for (var a = 0; a < node.Aggregations.Count; a++)
+            {
+                var series = new JsonArray();
+                for (var i = 0; i < binCount; i++)
+                {
+                    var rows = state.BinRows[i];
+                    if (rows.Count == 0)
+                    {
+                        series.Add(ToJson(node.Defaults[a]));
+                        continue;
+                    }
+
+                    var binChunk = new TableChunk(chunk.Table,
+                        chunk.Columns.Select(c => ColumnHelpers.MapColumn(c, rows.ToImmutableArray())).ToArray());
+                    var aggResult = node.Aggregations[a].Accept(this, context with { Chunk = binChunk });
+                    var value = aggResult is ScalarResult sr ? sr.Value : null;
+                    series.Add(ToJson(value));
+                }
+                outBuilders[outCol++].Add(series);
+            }
+        }
+
+        var outColumns = outBuilders.Select(b => b.ToColumn()).ToArray();
+        return TabularResult.CreateUnvisualized(new InMemoryTableSource(resultSchema, outColumns));
+    }
+
+    private static double ToDouble(object? v) => v switch
+    {
+        DateTime dt => dt.Ticks,
+        TimeSpan ts => ts.Ticks,
+        long l => l,
+        int i => i,
+        double d => d,
+        decimal m => (double)m,
+        _ => 0
+    };
+
+    private static JsonNode? ToJson(object? v) => v switch
+    {
+        null => null,
+        long l => JsonValue.Create(l),
+        int i => JsonValue.Create(i),
+        double d => JsonValue.Create(d),
+        decimal m => JsonValue.Create(m),
+        bool b => JsonValue.Create(b),
+        DateTime dt => JsonValue.Create(dt.ToString("o")),
+        string s => JsonValue.Create(s),
+        JsonNode j => j.DeepClone(),
+        _ => JsonValue.Create(v.ToString())
+    };
+
+    private sealed class GroupState
+    {
+        public GroupState(int binCount)
+        {
+            BinRows = new List<int>[binCount];
+            for (var i = 0; i < binCount; i++) BinRows[i] = new List<int>();
+        }
+
+        public List<int>[] BinRows { get; }
+    }
+
+    private readonly struct GroupKey : IEquatable<GroupKey>
+    {
+        public GroupKey(object?[] values) => Values = values;
+        public object?[] Values { get; }
+
+        public bool Equals(GroupKey other)
+        {
+            if (Values.Length != other.Values.Length) return false;
+            for (var i = 0; i < Values.Length; i++)
+                if (!Equals(Values[i], other.Values[i])) return false;
+            return true;
+        }
+
+        public override bool Equals(object? obj) => obj is GroupKey g && Equals(g);
+
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            foreach (var v in Values) hash.Add(v);
+            return hash.ToHashCode();
+        }
+    }
+}

--- a/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.MvApply.cs
+++ b/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.MvApply.cs
@@ -62,6 +62,13 @@ internal partial class TreeEvaluator
 
                 var subtable = BuildExpandedSubtable(sourceRow, expandedValues, inputSchema, intermediateSchema,
                     intermediateColumns, expandNames, node);
+
+                // An expansion that yields nothing contributes nothing: mv-apply is a lateral join, so a source row
+                // whose arrays are all empty produces no output rows (unlike mv-expand, which keeps the row with a
+                // null). Running the subquery anyway would resurrect it, because an aggregate over an empty table
+                // still emits a row.
+                if (subtable.GetData().Sum(c => c.RowCount) == 0) continue;
+
                 var subContext = context with { Left = TabularResult.CreateUnvisualized(subtable) };
                 var subResult = (TabularResult)node.Subquery.Accept(this, subContext);
                 var subSchema = subResult.Value.Type;

--- a/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.MvApply.cs
+++ b/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.MvApply.cs
@@ -1,0 +1,117 @@
+//
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Kusto.Language.Symbols;
+using KustoLoco.Core.DataSource;
+using KustoLoco.Core.DataSource.Columns;
+using KustoLoco.Core.Evaluation.BuiltIns.Impl;
+using KustoLoco.Core.InternalRepresentation.Nodes.Expressions.QueryOperators;
+using KustoLoco.Core.Util;
+
+namespace KustoLoco.Core.Evaluation;
+
+internal partial class TreeEvaluator
+{
+    public override EvaluationResult VisitMvApplyOperator(IRMvApplyOperatorNode node, EvaluationContext context)
+    {
+        var input = context.Left.Value;
+        var inputSchema = input.Type;
+        var resultSchema = (TableSymbol)node.ResultType;
+
+        // Intermediate schema = the input columns, with each expanded column retyped to its element type (same order as
+        // the input). The subquery is bound against this schema.
+        var expandNames = new HashSet<string>(node.Columns.Select(c => c.ColumnSymbol.Name));
+        var expandByName = node.Columns.ToDictionary(c => c.ColumnSymbol.Name, c => c.ColumnSymbol);
+        var intermediateColumns = inputSchema.Columns
+            .Select(c => expandByName.TryGetValue(c.Name, out var ec) ? ec : c)
+            .ToArray();
+        var intermediateSchema = new TableSymbol(intermediateColumns);
+
+        var outBuilders = ColumnHelpers.CreateBuildersForTable(resultSchema);
+
+        foreach (var chunk in input.GetData())
+        {
+            for (var row = 0; row < chunk.RowCount; row++)
+            {
+                // Read this source row once (input columns are single-pass).
+                var sourceRow = new object?[inputSchema.Columns.Count];
+                for (var i = 0; i < inputSchema.Columns.Count; i++)
+                    sourceRow[i] = chunk.Columns[i].GetRawDataValue(row);
+
+                var subtable = BuildExpandedSubtable(sourceRow, inputSchema, intermediateSchema, intermediateColumns,
+                    expandNames, node);
+                var subContext = context with { Left = TabularResult.CreateUnvisualized(subtable) };
+                var subResult = (TabularResult)node.Subquery.Accept(this, subContext);
+                var subSchema = subResult.Value.Type;
+
+                // Each result column comes from the subquery output (by name) if present, otherwise it is a surviving
+                // source column, replicated across all of this source row's subquery output rows.
+                foreach (var subChunk in subResult.Value.GetData())
+                    for (var subRow = 0; subRow < subChunk.RowCount; subRow++)
+                        for (var col = 0; col < resultSchema.Columns.Count; col++)
+                        {
+                            var name = resultSchema.Columns[col].Name;
+                            var subIdx = IndexOf(subSchema, name);
+                            object? value;
+                            if (subIdx >= 0)
+                            {
+                                value = subChunk.Columns[subIdx].GetRawDataValue(subRow);
+                            }
+                            else
+                            {
+                                var srcIdx = IndexOf(inputSchema, name);
+                                value = srcIdx >= 0 ? sourceRow[srcIdx] : null;
+                            }
+                            outBuilders[col].Add(value);
+                        }
+            }
+        }
+
+        var outputColumns = outBuilders.Select(b => b.ToColumn()).ToArray();
+        return TabularResult.CreateUnvisualized(new InMemoryTableSource(resultSchema, outputColumns));
+    }
+
+    private static InMemoryTableSource BuildExpandedSubtable(object?[] sourceRow, TableSymbol inputSchema,
+        TableSymbol intermediateSchema, ColumnSymbol[] intermediateColumns, HashSet<string> expandNames,
+        IRMvApplyOperatorNode node)
+    {
+        // Expand each expanded column's array for this source row; the subtable has as many rows as the longest array.
+        var elementArrays = new Dictionary<string, object?[]>();
+        var maxLen = 0;
+        foreach (var expandCol in node.Columns)
+        {
+            var srcIdx = IndexOf(inputSchema, expandCol.ColumnSymbol.Name);
+            var arr = JsonArrayHelper.ToObjectArrayOfType(sourceRow[srcIdx], expandCol.ColumnSymbol.Type);
+            elementArrays[expandCol.ColumnSymbol.Name] = arr;
+            if (arr.Length > maxLen) maxLen = arr.Length;
+        }
+        if (node.RowLimit is { } limit && maxLen > limit) maxLen = (int)limit;
+
+        var builders = ColumnHelpers.CreateBuildersForTable(intermediateSchema);
+        for (var i = 0; i < intermediateColumns.Length; i++)
+        {
+            var colSym = intermediateColumns[i];
+            if (expandNames.Contains(colSym.Name))
+            {
+                var arr = elementArrays[colSym.Name];
+                for (var e = 0; e < maxLen; e++) builders[i].Add(e < arr.Length ? arr[e] : null);
+            }
+            else
+            {
+                var srcIdx = IndexOf(inputSchema, colSym.Name);
+                for (var e = 0; e < maxLen; e++) builders[i].Add(sourceRow[srcIdx]);
+            }
+        }
+
+        return new InMemoryTableSource(intermediateSchema, builders.Select(b => b.ToColumn()).ToArray());
+    }
+
+    private static int IndexOf(TableSymbol schema, string name)
+    {
+        for (var i = 0; i < schema.Columns.Count; i++)
+            if (schema.Columns[i].Name == name) return i;
+        return -1;
+    }
+}

--- a/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.MvApply.cs
+++ b/libraries/KustoLoco.Core/Evaluation/TreeEvaluator.QueryOperators.MvApply.cs
@@ -24,15 +24,30 @@ internal partial class TreeEvaluator
         // the input). The subquery is bound against this schema.
         var expandNames = new HashSet<string>(node.Columns.Select(c => c.ColumnSymbol.Name));
         var expandByName = node.Columns.ToDictionary(c => c.ColumnSymbol.Name, c => c.ColumnSymbol);
+        // Input columns, with any expanded one retyped to its element type, PLUS any expanded column that is NOT an
+        // input column at all — an aliased expression (`p = parse_json(Col)`) introduces a new name the subquery
+        // must be able to bind.
         var intermediateColumns = inputSchema.Columns
             .Select(c => expandByName.TryGetValue(c.Name, out var ec) ? ec : c)
+            .Concat(node.Columns
+                .Select(c => c.ColumnSymbol)
+                .Where(cs => IndexOf(inputSchema, cs.Name) < 0))
             .ToArray();
         var intermediateSchema = new TableSymbol(intermediateColumns);
 
         var outBuilders = ColumnHelpers.CreateBuildersForTable(resultSchema);
 
-        foreach (var chunk in input.GetData())
+        // Materialize the input once so both the expanded expressions and the per-row reads below see the same data
+        // (chunk columns are single-pass), then evaluate each expanded expression COLUMNAR over that chunk. The
+        // expanded item is an expression, not necessarily a source column — `mv-apply p = parse_json(Col) on (...)`
+        // aliases a computed value that is absent from the input schema — so it must be evaluated, never looked up.
         {
+            var chunk = ChunkHelpers.Reassemble(input.GetData().ToArray());
+            var chunkContext = context with { Chunk = chunk };
+            var expandedColumns = node.Columns
+                .Select(c => ((ColumnarResult)c.Expression.Accept(this, chunkContext)).Column)
+                .ToArray();
+
             for (var row = 0; row < chunk.RowCount; row++)
             {
                 // Read this source row once (input columns are single-pass).
@@ -40,8 +55,13 @@ internal partial class TreeEvaluator
                 for (var i = 0; i < inputSchema.Columns.Count; i++)
                     sourceRow[i] = chunk.Columns[i].GetRawDataValue(row);
 
-                var subtable = BuildExpandedSubtable(sourceRow, inputSchema, intermediateSchema, intermediateColumns,
-                    expandNames, node);
+                // The value to expand per expanded column, taken from the evaluated expression for this row.
+                var expandedValues = new object?[expandedColumns.Length];
+                for (var i = 0; i < expandedColumns.Length; i++)
+                    expandedValues[i] = expandedColumns[i].GetRawDataValue(row);
+
+                var subtable = BuildExpandedSubtable(sourceRow, expandedValues, inputSchema, intermediateSchema,
+                    intermediateColumns, expandNames, node);
                 var subContext = context with { Left = TabularResult.CreateUnvisualized(subtable) };
                 var subResult = (TabularResult)node.Subquery.Accept(this, subContext);
                 var subSchema = subResult.Value.Type;
@@ -73,17 +93,19 @@ internal partial class TreeEvaluator
         return TabularResult.CreateUnvisualized(new InMemoryTableSource(resultSchema, outputColumns));
     }
 
-    private static InMemoryTableSource BuildExpandedSubtable(object?[] sourceRow, TableSymbol inputSchema,
-        TableSymbol intermediateSchema, ColumnSymbol[] intermediateColumns, HashSet<string> expandNames,
-        IRMvApplyOperatorNode node)
+    private static InMemoryTableSource BuildExpandedSubtable(object?[] sourceRow, object?[] expandedValues,
+        TableSymbol inputSchema, TableSymbol intermediateSchema, ColumnSymbol[] intermediateColumns,
+        HashSet<string> expandNames, IRMvApplyOperatorNode node)
     {
         // Expand each expanded column's array for this source row; the subtable has as many rows as the longest array.
+        // The value comes from the EVALUATED expression (expandedValues), not from a name lookup against the input —
+        // the expanded item may be an alias for a computed expression that is absent from the input schema.
         var elementArrays = new Dictionary<string, object?[]>();
         var maxLen = 0;
-        foreach (var expandCol in node.Columns)
+        for (var c = 0; c < node.Columns.Count; c++)
         {
-            var srcIdx = IndexOf(inputSchema, expandCol.ColumnSymbol.Name);
-            var arr = JsonArrayHelper.ToObjectArrayOfType(sourceRow[srcIdx], expandCol.ColumnSymbol.Type);
+            var expandCol = node.Columns[c];
+            var arr = JsonArrayHelper.ToObjectArrayOfType(expandedValues[c], expandCol.ColumnSymbol.Type);
             elementArrays[expandCol.ColumnSymbol.Name] = arr;
             if (arr.Length > maxLen) maxLen = arr.Length;
         }

--- a/libraries/KustoLoco.Core/InternalRepresentation/DefaultIRNodeVisitor.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/DefaultIRNodeVisitor.cs
@@ -138,4 +138,7 @@ internal abstract class DefaultIRNodeVisitor<TResult, TContext> : IRNodeVisitor<
     public override TResult VisitMakeSeriesOperator(IRMakeSeriesOperatorNode node, TContext context) =>
         DefaultVisit(node, context);
 
+    public override TResult VisitIpv4LookupOperator(IRIpv4LookupOperatorNode node, TContext context) =>
+        DefaultVisit(node, context);
+
 }

--- a/libraries/KustoLoco.Core/InternalRepresentation/DefaultIRNodeVisitor.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/DefaultIRNodeVisitor.cs
@@ -135,4 +135,7 @@ internal abstract class DefaultIRNodeVisitor<TResult, TContext> : IRNodeVisitor<
     public override TResult VisitExternalDataExpression(IRExternalDataExpression node, TContext context) =>
         DefaultVisit(node, context);
 
+    public override TResult VisitMakeSeriesOperator(IRMakeSeriesOperatorNode node, TContext context) =>
+        DefaultVisit(node, context);
+
 }

--- a/libraries/KustoLoco.Core/InternalRepresentation/DefaultIRNodeVisitor.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/DefaultIRNodeVisitor.cs
@@ -132,4 +132,7 @@ internal abstract class DefaultIRNodeVisitor<TResult, TContext> : IRNodeVisitor<
     public override TResult VisitMvApplyOperator(IRMvApplyOperatorNode node, TContext context) =>
         DefaultVisit(node, context);
 
+    public override TResult VisitExternalDataExpression(IRExternalDataExpression node, TContext context) =>
+        DefaultVisit(node, context);
+
 }

--- a/libraries/KustoLoco.Core/InternalRepresentation/DefaultIRNodeVisitor.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/DefaultIRNodeVisitor.cs
@@ -129,4 +129,7 @@ internal abstract class DefaultIRNodeVisitor<TResult, TContext> : IRNodeVisitor<
     public override TResult VisitMvExpandOperator(IRMvExpandOperatorNode node, TContext context) =>
         DefaultVisit(node, context);
 
+    public override TResult VisitMvApplyOperator(IRMvApplyOperatorNode node, TContext context) =>
+        DefaultVisit(node, context);
+
 }

--- a/libraries/KustoLoco.Core/InternalRepresentation/IRNodeVisitor.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/IRNodeVisitor.cs
@@ -52,5 +52,6 @@ internal abstract class IRNodeVisitor<TResult, TContext>
     public abstract TResult VisitMvApplyOperator(IRMvApplyOperatorNode node, TContext context);
     public abstract TResult VisitExternalDataExpression(IRExternalDataExpression node, TContext context);
     public abstract TResult VisitMakeSeriesOperator(IRMakeSeriesOperatorNode node, TContext context);
+    public abstract TResult VisitIpv4LookupOperator(IRIpv4LookupOperatorNode node, TContext context);
 
 }

--- a/libraries/KustoLoco.Core/InternalRepresentation/IRNodeVisitor.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/IRNodeVisitor.cs
@@ -49,5 +49,6 @@ internal abstract class IRNodeVisitor<TResult, TContext>
     public abstract TResult VisitRangeOperator(IRRangeOperatorNode node, TContext context);
     public abstract TResult VisitStarExpression(IRStarExpression node, TContext context);
     public abstract TResult VisitMvExpandOperator(IRMvExpandOperatorNode node, TContext context);
+    public abstract TResult VisitMvApplyOperator(IRMvApplyOperatorNode node, TContext context);
 
 }

--- a/libraries/KustoLoco.Core/InternalRepresentation/IRNodeVisitor.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/IRNodeVisitor.cs
@@ -50,5 +50,6 @@ internal abstract class IRNodeVisitor<TResult, TContext>
     public abstract TResult VisitStarExpression(IRStarExpression node, TContext context);
     public abstract TResult VisitMvExpandOperator(IRMvExpandOperatorNode node, TContext context);
     public abstract TResult VisitMvApplyOperator(IRMvApplyOperatorNode node, TContext context);
+    public abstract TResult VisitExternalDataExpression(IRExternalDataExpression node, TContext context);
 
 }

--- a/libraries/KustoLoco.Core/InternalRepresentation/IRNodeVisitor.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/IRNodeVisitor.cs
@@ -51,5 +51,6 @@ internal abstract class IRNodeVisitor<TResult, TContext>
     public abstract TResult VisitMvExpandOperator(IRMvExpandOperatorNode node, TContext context);
     public abstract TResult VisitMvApplyOperator(IRMvApplyOperatorNode node, TContext context);
     public abstract TResult VisitExternalDataExpression(IRExternalDataExpression node, TContext context);
+    public abstract TResult VisitMakeSeriesOperator(IRMakeSeriesOperatorNode node, TContext context);
 
 }

--- a/libraries/KustoLoco.Core/InternalRepresentation/Nodes/Expressions/IRExternalDataExpression.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/Nodes/Expressions/IRExternalDataExpression.cs
@@ -1,0 +1,30 @@
+//
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Kusto.Language.Symbols;
+
+namespace KustoLoco.Core.InternalRepresentation.Nodes.Expressions;
+
+// externaldata (Col:type, ...) [uri, ...] with(format=...): a tabular expression whose rows come from data the HOST
+// fetches. The engine holds only the declared schema, the URIs and the requested format; fetching is delegated to a
+// host-registered IExternalDataResolver so the engine itself never performs network access.
+internal class IRExternalDataExpression : IRExpressionNode
+{
+    public IRExternalDataExpression(IReadOnlyList<string> uris, string format, TypeSymbol resultType)
+        : base(resultType, EvaluatedExpressionKind.Table)
+    {
+        Uris = uris ?? throw new ArgumentNullException(nameof(uris));
+        Format = format;
+    }
+
+    public IReadOnlyList<string> Uris { get; }
+
+    public string Format { get; }
+
+    public override TResult Accept<TResult, TContext>(IRNodeVisitor<TResult, TContext> visitor, TContext context)
+        => visitor.VisitExternalDataExpression(this, context);
+
+    public override string ToString() => $"ExternalDataExpression: {SchemaDisplay.GetText(ResultType)}";
+}

--- a/libraries/KustoLoco.Core/InternalRepresentation/Nodes/Expressions/QueryOperators/IRIpv4LookupOperatorNode.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/Nodes/Expressions/QueryOperators/IRIpv4LookupOperatorNode.cs
@@ -1,0 +1,34 @@
+//
+// Licensed under the MIT License.
+
+using System;
+using Kusto.Language.Symbols;
+
+namespace KustoLoco.Core.InternalRepresentation.Nodes.Expressions.QueryOperators;
+
+// evaluate ipv4_lookup(LookupTable, SourceIpKey, IpLookupKey): joins the source rows to LookupTable by matching the
+// source IP (SourceIpKey) against the CIDR range in LookupTable's IpLookupKey column, appending the lookup columns.
+internal class IRIpv4LookupOperatorNode : IRQueryOperatorNode
+{
+    public IRIpv4LookupOperatorNode(IRExpressionNode lookupTable, IRExpressionNode sourceIp, string lookupIpColumn,
+        bool returnUnmatched, TypeSymbol resultType)
+        : base(resultType)
+    {
+        LookupTable = lookupTable ?? throw new ArgumentNullException(nameof(lookupTable));
+        SourceIp = sourceIp ?? throw new ArgumentNullException(nameof(sourceIp));
+        LookupIpColumn = lookupIpColumn;
+        ReturnUnmatched = returnUnmatched;
+    }
+
+    public IRExpressionNode LookupTable { get; }
+    public IRExpressionNode SourceIp { get; }
+    public string LookupIpColumn { get; }
+    public bool ReturnUnmatched { get; }
+
+    public override int ChildCount => 2;
+
+    public override IRNode GetChild(int index) => index == 0 ? LookupTable : SourceIp;
+
+    public override TResult Accept<TResult, TContext>(IRNodeVisitor<TResult, TContext> visitor, TContext context)
+        => visitor.VisitIpv4LookupOperator(this, context);
+}

--- a/libraries/KustoLoco.Core/InternalRepresentation/Nodes/Expressions/QueryOperators/IRIpv4LookupOperatorNode.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/Nodes/Expressions/QueryOperators/IRIpv4LookupOperatorNode.cs
@@ -2,27 +2,32 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using Kusto.Language.Symbols;
 
 namespace KustoLoco.Core.InternalRepresentation.Nodes.Expressions.QueryOperators;
 
-// evaluate ipv4_lookup(LookupTable, SourceIpKey, IpLookupKey): joins the source rows to LookupTable by matching the
-// source IP (SourceIpKey) against the CIDR range in LookupTable's IpLookupKey column, appending the lookup columns.
+// evaluate ipv4_lookup(LookupTable, SourceIpKey, IpLookupKey [, ExtraKey1 .. ExtraKeyN] [, return_unmatched]): joins the
+// source rows to LookupTable by matching the source IP (SourceIpKey) against the CIDR range in LookupTable's
+// IpLookupKey column, appending the lookup columns. ExtraKeys are columns present in BOTH tables that must additionally
+// match by equality; return_unmatched keeps unmatched source rows (lookup columns null) instead of dropping them.
 internal class IRIpv4LookupOperatorNode : IRQueryOperatorNode
 {
     public IRIpv4LookupOperatorNode(IRExpressionNode lookupTable, IRExpressionNode sourceIp, string lookupIpColumn,
-        bool returnUnmatched, TypeSymbol resultType)
+        IReadOnlyList<string> extraKeys, bool returnUnmatched, TypeSymbol resultType)
         : base(resultType)
     {
         LookupTable = lookupTable ?? throw new ArgumentNullException(nameof(lookupTable));
         SourceIp = sourceIp ?? throw new ArgumentNullException(nameof(sourceIp));
         LookupIpColumn = lookupIpColumn;
+        ExtraKeys = extraKeys ?? throw new ArgumentNullException(nameof(extraKeys));
         ReturnUnmatched = returnUnmatched;
     }
 
     public IRExpressionNode LookupTable { get; }
     public IRExpressionNode SourceIp { get; }
     public string LookupIpColumn { get; }
+    public IReadOnlyList<string> ExtraKeys { get; }
     public bool ReturnUnmatched { get; }
 
     public override int ChildCount => 2;

--- a/libraries/KustoLoco.Core/InternalRepresentation/Nodes/Expressions/QueryOperators/IRMakeSeriesOperatorNode.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/Nodes/Expressions/QueryOperators/IRMakeSeriesOperatorNode.cs
@@ -15,6 +15,7 @@ internal class IRMakeSeriesOperatorNode : IRQueryOperatorNode
     public IRMakeSeriesOperatorNode(
         List<IRExpressionNode> aggregations,
         List<object?> defaults,
+        List<bool> defaultProvided,
         IRExpressionNode axis,
         IRExpressionNode from,
         IRExpressionNode to,
@@ -25,6 +26,7 @@ internal class IRMakeSeriesOperatorNode : IRQueryOperatorNode
     {
         Aggregations = aggregations ?? throw new ArgumentNullException(nameof(aggregations));
         Defaults = defaults ?? throw new ArgumentNullException(nameof(defaults));
+        DefaultProvided = defaultProvided ?? throw new ArgumentNullException(nameof(defaultProvided));
         Axis = axis ?? throw new ArgumentNullException(nameof(axis));
         From = from ?? throw new ArgumentNullException(nameof(from));
         To = to ?? throw new ArgumentNullException(nameof(to));
@@ -44,6 +46,9 @@ internal class IRMakeSeriesOperatorNode : IRQueryOperatorNode
 
     public List<IRExpressionNode> Aggregations { get; }
     public List<object?> Defaults { get; }
+    // Whether a 'default=' clause was written for each aggregate. Distinguishes "no default" (ADX fills gaps with a
+    // typed 0) from an explicit 'default=<null>' (fills with null, e.g. for the series_fill_* interpolation functions).
+    public List<bool> DefaultProvided { get; }
     public IRExpressionNode Axis { get; }
     public IRExpressionNode From { get; }
     public IRExpressionNode To { get; }

--- a/libraries/KustoLoco.Core/InternalRepresentation/Nodes/Expressions/QueryOperators/IRMakeSeriesOperatorNode.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/Nodes/Expressions/QueryOperators/IRMakeSeriesOperatorNode.cs
@@ -21,12 +21,14 @@ internal class IRMakeSeriesOperatorNode : IRQueryOperatorNode
         IRExpressionNode to,
         IRExpressionNode step,
         List<IRExpressionNode> byColumns,
+        bool stopInclusive,
         TypeSymbol resultType)
         : base(resultType)
     {
         Aggregations = aggregations ?? throw new ArgumentNullException(nameof(aggregations));
         Defaults = defaults ?? throw new ArgumentNullException(nameof(defaults));
         DefaultProvided = defaultProvided ?? throw new ArgumentNullException(nameof(defaultProvided));
+        StopInclusive = stopInclusive;
         Axis = axis ?? throw new ArgumentNullException(nameof(axis));
         From = from ?? throw new ArgumentNullException(nameof(from));
         To = to ?? throw new ArgumentNullException(nameof(to));
@@ -54,6 +56,10 @@ internal class IRMakeSeriesOperatorNode : IRQueryOperatorNode
     public IRExpressionNode To { get; }
     public IRExpressionNode Step { get; }
     public List<IRExpressionNode> ByColumns { get; }
+    // The alternate 'in range(start, stop, step)' syntax has an INCLUSIVE stop (unlike 'from .. to ..' where 'to' is
+    // non-inclusive), so the last axis point can equal stop. (range() also bins with bin() rather than bin_at(); for the
+    // usual step-aligned start the two coincide.)
+    public bool StopInclusive { get; }
 
     public override int ChildCount => _children.Count;
 

--- a/libraries/KustoLoco.Core/InternalRepresentation/Nodes/Expressions/QueryOperators/IRMakeSeriesOperatorNode.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/Nodes/Expressions/QueryOperators/IRMakeSeriesOperatorNode.cs
@@ -1,0 +1,59 @@
+//
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Kusto.Language.Symbols;
+
+namespace KustoLoco.Core.InternalRepresentation.Nodes.Expressions.QueryOperators;
+
+// make-series Aggregations [default=..] on Axis from From to To step Step by ByColumns: groups rows by ByColumns,
+// bins the Axis into [From, To) buckets of width Step, aggregates within each bucket, gap-fills empty buckets with the
+// per-aggregate default, and returns one row per group whose Axis and aggregate columns are dynamic-array series.
+internal class IRMakeSeriesOperatorNode : IRQueryOperatorNode
+{
+    public IRMakeSeriesOperatorNode(
+        List<IRExpressionNode> aggregations,
+        List<object?> defaults,
+        IRExpressionNode axis,
+        IRExpressionNode from,
+        IRExpressionNode to,
+        IRExpressionNode step,
+        List<IRExpressionNode> byColumns,
+        TypeSymbol resultType)
+        : base(resultType)
+    {
+        Aggregations = aggregations ?? throw new ArgumentNullException(nameof(aggregations));
+        Defaults = defaults ?? throw new ArgumentNullException(nameof(defaults));
+        Axis = axis ?? throw new ArgumentNullException(nameof(axis));
+        From = from ?? throw new ArgumentNullException(nameof(from));
+        To = to ?? throw new ArgumentNullException(nameof(to));
+        Step = step ?? throw new ArgumentNullException(nameof(step));
+        ByColumns = byColumns ?? throw new ArgumentNullException(nameof(byColumns));
+
+        _children = new List<IRNode>();
+        _children.AddRange(aggregations);
+        _children.Add(axis);
+        _children.Add(from);
+        _children.Add(to);
+        _children.Add(step);
+        _children.AddRange(byColumns);
+    }
+
+    private readonly List<IRNode> _children;
+
+    public List<IRExpressionNode> Aggregations { get; }
+    public List<object?> Defaults { get; }
+    public IRExpressionNode Axis { get; }
+    public IRExpressionNode From { get; }
+    public IRExpressionNode To { get; }
+    public IRExpressionNode Step { get; }
+    public List<IRExpressionNode> ByColumns { get; }
+
+    public override int ChildCount => _children.Count;
+
+    public override IRNode GetChild(int index) => _children[index];
+
+    public override TResult Accept<TResult, TContext>(IRNodeVisitor<TResult, TContext> visitor, TContext context)
+        => visitor.VisitMakeSeriesOperator(this, context);
+}

--- a/libraries/KustoLoco.Core/InternalRepresentation/Nodes/Expressions/QueryOperators/IRMvApplyOperatorNode.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/Nodes/Expressions/QueryOperators/IRMvApplyOperatorNode.cs
@@ -1,0 +1,36 @@
+//
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Kusto.Language.Symbols;
+
+namespace KustoLoco.Core.InternalRepresentation.Nodes.Expressions.QueryOperators;
+
+// mv-apply: expand the named columns (as mv-expand does) but, per source row, run the subquery pipeline over just that
+// row's expanded rows and union the results. Columns reuse the mv-expand column node; Subquery is the pipeline to apply.
+internal class IRMvApplyOperatorNode : IRQueryOperatorNode
+{
+    public IRMvApplyOperatorNode(List<IRMvExpandColumnNode> columns, IRExpressionNode subquery,
+        long? rowLimit, TypeSymbol resultType)
+        : base(resultType)
+    {
+        Columns = columns ?? throw new ArgumentNullException(nameof(columns));
+        Subquery = subquery ?? throw new ArgumentNullException(nameof(subquery));
+        RowLimit = rowLimit;
+    }
+
+    public List<IRMvExpandColumnNode> Columns { get; }
+
+    public IRExpressionNode Subquery { get; }
+
+    public long? RowLimit { get; }
+
+    public override int ChildCount => Columns.Count + 1;
+
+    public override IRNode GetChild(int index) =>
+        index < Columns.Count ? Columns[index].Expression : Subquery;
+
+    public override TResult Accept<TResult, TContext>(IRNodeVisitor<TResult, TContext> visitor, TContext context)
+        => visitor.VisitMvApplyOperator(this, context);
+}

--- a/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.ExternalData.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.ExternalData.cs
@@ -1,0 +1,30 @@
+//
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Kusto.Language.Syntax;
+using KustoLoco.Core.InternalRepresentation.Nodes.Expressions;
+
+namespace KustoLoco.Core.InternalRepresentation;
+
+internal partial class IRTranslator
+{
+    public override IRNode VisitExternalDataExpression(ExternalDataExpression node)
+    {
+        var uris = new List<string>();
+        foreach (var uriElement in node.URIs)
+            if (uriElement.Element.Accept(this) is IRLiteralExpressionNode { Value: string uri })
+                uris.Add(uri);
+
+        var format = "csv";
+        if (node.WithClause != null)
+            foreach (var property in node.WithClause.Properties)
+                if (property.Element is NamedParameter np &&
+                    string.Equals(np.Name.SimpleName, "format", StringComparison.OrdinalIgnoreCase) &&
+                    np.Expression.Accept(this) is IRLiteralExpressionNode { Value: string f })
+                    format = f;
+
+        return new IRExternalDataExpression(uris, format, node.ResultType);
+    }
+}

--- a/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.Ipv4Lookup.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.Ipv4Lookup.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using Kusto.Language.Syntax;
 using KustoLoco.Core.InternalRepresentation.Nodes.Expressions;
 using KustoLoco.Core.InternalRepresentation.Nodes.Expressions.QueryOperators;
@@ -16,6 +17,7 @@ internal partial class IRTranslator
         if (!string.Equals(pluginName, "ipv4_lookup", StringComparison.OrdinalIgnoreCase))
             throw new NotImplementedException($"evaluate plugin '{pluginName}' is not supported.");
 
+        // ipv4_lookup(LookupTable, SourceIPv4Key, IPv4LookupKey [, ExtraKey1 .. ExtraKeyN] [, return_unmatched])
         var args = node.FunctionCall.ArgumentList.Expressions;
         if (args.Count < 3)
             throw new NotImplementedException("ipv4_lookup requires (LookupTable, SourceIpKey, IpLookupKey).");
@@ -24,8 +26,42 @@ internal partial class IRTranslator
         // of the CIDR column in the lookup table, taken as a bareword (it is not a source column).
         var lookupTable = (IRExpressionNode)args[0].Element.Accept(this);
         var sourceIp = (IRExpressionNode)args[1].Element.Accept(this);
-        var lookupIpColumn = args[2].Element is NameReference nr ? nr.SimpleName : args[2].Element.ToString().Trim();
+        var lookupIpColumn = NameOf(args[2].Element);
 
-        return new IRIpv4LookupOperatorNode(lookupTable, sourceIp, lookupIpColumn, false, node.ResultType);
+        // The optional trailing return_unmatched flag may be written positionally (`.., true`) or named
+        // (`.., return_unmatched = true`). Any other trailing arguments are ExtraKeys: column names that must exist in
+        // BOTH tables and match by equality, narrowing the IPv4 match (like additional join keys).
+        var returnUnmatched = false;
+        var extraKeys = new List<string>();
+        for (var i = 3; i < args.Count; i++)
+        {
+            var element = args[i].Element;
+            if (TryGetBooleanFlag(element, out var flag))
+            {
+                returnUnmatched = flag;
+                continue;
+            }
+            extraKeys.Add(NameOf(element));
+        }
+
+        return new IRIpv4LookupOperatorNode(lookupTable, sourceIp, lookupIpColumn, extraKeys, returnUnmatched,
+            node.ResultType);
+    }
+
+    private static string NameOf(Expression expression) =>
+        expression is NameReference nr ? nr.SimpleName : expression.ToString().Trim();
+
+    // Recognises `true` / `false`, and the named form `return_unmatched = true` (a named argument parses as a simple
+    // named expression whose value is the literal).
+    private static bool TryGetBooleanFlag(Expression expression, out bool value)
+    {
+        value = false;
+        var candidate = expression is SimpleNamedExpression named ? named.Expression : expression;
+        if (candidate is LiteralExpression literal && literal.LiteralValue is bool b)
+        {
+            value = b;
+            return true;
+        }
+        return false;
     }
 }

--- a/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.Ipv4Lookup.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.Ipv4Lookup.cs
@@ -1,0 +1,31 @@
+//
+// Licensed under the MIT License.
+
+using System;
+using Kusto.Language.Syntax;
+using KustoLoco.Core.InternalRepresentation.Nodes.Expressions;
+using KustoLoco.Core.InternalRepresentation.Nodes.Expressions.QueryOperators;
+
+namespace KustoLoco.Core.InternalRepresentation;
+
+internal partial class IRTranslator
+{
+    public override IRNode VisitEvaluateOperator(EvaluateOperator node)
+    {
+        var pluginName = node.FunctionCall.Name.SimpleName;
+        if (!string.Equals(pluginName, "ipv4_lookup", StringComparison.OrdinalIgnoreCase))
+            throw new NotImplementedException($"evaluate plugin '{pluginName}' is not supported.");
+
+        var args = node.FunctionCall.ArgumentList.Expressions;
+        if (args.Count < 3)
+            throw new NotImplementedException("ipv4_lookup requires (LookupTable, SourceIpKey, IpLookupKey).");
+
+        // LookupTable resolves as a tabular reference; SourceIpKey is a source-row expression; IpLookupKey is the name
+        // of the CIDR column in the lookup table, taken as a bareword (it is not a source column).
+        var lookupTable = (IRExpressionNode)args[0].Element.Accept(this);
+        var sourceIp = (IRExpressionNode)args[1].Element.Accept(this);
+        var lookupIpColumn = args[2].Element is NameReference nr ? nr.SimpleName : args[2].Element.ToString().Trim();
+
+        return new IRIpv4LookupOperatorNode(lookupTable, sourceIp, lookupIpColumn, false, node.ResultType);
+    }
+}

--- a/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.MakeSeries.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.MakeSeries.cs
@@ -56,7 +56,10 @@ internal partial class IRTranslator
             foreach (var byElement in node.ByClause.Expressions)
                 byColumns.Add((IRExpressionNode)byElement.Element.Accept(this));
 
+        // The 'in range(start, stop, step)' alternate syntax has an inclusive stop; 'from .. to ..' does not.
+        var stopInclusive = node.RangeClause is MakeSeriesInRangeClause;
+
         return new IRMakeSeriesOperatorNode(aggregations, defaults, defaultProvided, axis, from, to, step, byColumns,
-            node.ResultType);
+            stopInclusive, node.ResultType);
     }
 }

--- a/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.MakeSeries.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.MakeSeries.cs
@@ -15,14 +15,16 @@ internal partial class IRTranslator
     {
         var aggregations = new List<IRExpressionNode>();
         var defaults = new List<object?>();
+        var defaultProvided = new List<bool>();
         foreach (var aggElement in node.Aggregates)
         {
             if (aggElement.Element is not MakeSeriesExpression mse) continue;
             aggregations.Add((IRExpressionNode)mse.Expression.Accept(this));
             object? def = null;
-            if (mse.DefaultExpression?.Expression.Accept(this) is IRLiteralExpressionNode { Value: { } v })
-                def = v;
+            if (mse.DefaultExpression?.Expression.Accept(this) is IRLiteralExpressionNode lit)
+                def = lit.Value;
             defaults.Add(def);
+            defaultProvided.Add(mse.DefaultExpression is not null);
         }
 
         var axis = (IRExpressionNode)node.OnClause.Expression.Accept(this);
@@ -54,6 +56,7 @@ internal partial class IRTranslator
             foreach (var byElement in node.ByClause.Expressions)
                 byColumns.Add((IRExpressionNode)byElement.Element.Accept(this));
 
-        return new IRMakeSeriesOperatorNode(aggregations, defaults, axis, from, to, step, byColumns, node.ResultType);
+        return new IRMakeSeriesOperatorNode(aggregations, defaults, defaultProvided, axis, from, to, step, byColumns,
+            node.ResultType);
     }
 }

--- a/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.MakeSeries.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.MakeSeries.cs
@@ -1,0 +1,59 @@
+//
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Kusto.Language.Syntax;
+using KustoLoco.Core.InternalRepresentation.Nodes.Expressions;
+using KustoLoco.Core.InternalRepresentation.Nodes.Expressions.QueryOperators;
+
+namespace KustoLoco.Core.InternalRepresentation;
+
+internal partial class IRTranslator
+{
+    public override IRNode VisitMakeSeriesOperator(MakeSeriesOperator node)
+    {
+        var aggregations = new List<IRExpressionNode>();
+        var defaults = new List<object?>();
+        foreach (var aggElement in node.Aggregates)
+        {
+            if (aggElement.Element is not MakeSeriesExpression mse) continue;
+            aggregations.Add((IRExpressionNode)mse.Expression.Accept(this));
+            object? def = null;
+            if (mse.DefaultExpression?.Expression.Accept(this) is IRLiteralExpressionNode { Value: { } v })
+                def = v;
+            defaults.Add(def);
+        }
+
+        var axis = (IRExpressionNode)node.OnClause.Expression.Accept(this);
+
+        IRExpressionNode from, to, step;
+        if (node.RangeClause is MakeSeriesFromToStepClause fts)
+        {
+            from = (IRExpressionNode)(fts.MakeSeriesFromClause?.Expression
+                ?? throw new NotImplementedException("make-series requires an explicit 'from'")).Accept(this);
+            to = (IRExpressionNode)(fts.MakeSeriesToClause?.Expression
+                ?? throw new NotImplementedException("make-series requires an explicit 'to'")).Accept(this);
+            step = (IRExpressionNode)(fts.MakeSeriesStepClause?.Expression
+                ?? throw new NotImplementedException("make-series requires an explicit 'step'")).Accept(this);
+        }
+        else if (node.RangeClause is MakeSeriesInRangeClause ir)
+        {
+            var args = ir.Arguments.Expressions;
+            from = (IRExpressionNode)args[0].Element.Accept(this);
+            to = (IRExpressionNode)args[1].Element.Accept(this);
+            step = (IRExpressionNode)args[2].Element.Accept(this);
+        }
+        else
+        {
+            throw new NotImplementedException("make-series requires a 'from .. to .. step ..' or 'in_range(..)' range.");
+        }
+
+        var byColumns = new List<IRExpressionNode>();
+        if (node.ByClause != null)
+            foreach (var byElement in node.ByClause.Expressions)
+                byColumns.Add((IRExpressionNode)byElement.Element.Accept(this));
+
+        return new IRMakeSeriesOperatorNode(aggregations, defaults, axis, from, to, step, byColumns, node.ResultType);
+    }
+}

--- a/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.MvApply.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.MvApply.cs
@@ -1,0 +1,59 @@
+//
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Kusto.Language.Symbols;
+using Kusto.Language.Syntax;
+using KustoLoco.Core.InternalRepresentation.Nodes.Expressions;
+using KustoLoco.Core.InternalRepresentation.Nodes.Expressions.QueryOperators;
+
+namespace KustoLoco.Core.InternalRepresentation;
+
+internal partial class IRTranslator
+{
+    public override IRNode VisitMvApplyOperator(MvApplyOperator node)
+    {
+        var inputScope = _rowScope;
+        var columns = new List<IRMvExpandColumnNode>();
+        foreach (var element in node.Expressions)
+        {
+            if (element.Element is not MvApplyExpression mvApplyExpr) continue;
+
+            var actualExpression = mvApplyExpr.Expression;
+            if (actualExpression is SimpleNamedExpression namedExpr)
+                actualExpression = namedExpr.Expression;
+
+            // The source array expression resolves against the input row scope.
+            var irExpression = (IRExpressionNode)actualExpression.Accept(this);
+            var colName = GetExpandedColumnName(mvApplyExpr.Expression);
+
+            // 'to typeof(T)': T is a type expression, so its ReferencedSymbol (not ResultType) is the element type.
+            TypeSymbol? elementType = null;
+            var typeArgs = mvApplyExpr.ToTypeOf?.TypeOf?.Types;
+            if (typeArgs is { Count: > 0 } && typeArgs[0].Element is { } typeExpr)
+                elementType = typeExpr.ReferencedSymbol as TypeSymbol;
+            elementType ??= actualExpression.ResultType as TypeSymbol ?? ScalarTypes.Dynamic;
+
+            columns.Add(new IRMvExpandColumnNode(new ColumnSymbol(colName, elementType), irExpression));
+        }
+
+        // Translate the subquery with the intermediate schema (input columns, with expanded columns retyped to their
+        // element type) as the row scope, so the subquery's column references resolve against the expanded rows.
+        var expandByName = columns.ToDictionary(c => c.ColumnSymbol.Name, c => c.ColumnSymbol);
+        var interColumns = inputScope.Columns
+            .Select(c => expandByName.TryGetValue(c.Name, out var ec) ? ec : c)
+            .ToArray();
+
+        var oldRowScope = _rowScope;
+        _rowScope = new TableSymbol(interColumns);
+        var subquery = (IRExpressionNode)node.Subquery.Expression.Accept(this);
+        _rowScope = oldRowScope;
+
+        long? rowLimit = null;
+        if (node.RowLimitClause?.RowLimit is LiteralExpression { LiteralValue: long limit })
+            rowLimit = limit;
+
+        return new IRMvApplyOperatorNode(columns, subquery, rowLimit, node.ResultType);
+    }
+}

--- a/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.MvApply.cs
+++ b/libraries/KustoLoco.Core/InternalRepresentation/Translation/IRTranslator.MvApply.cs
@@ -1,6 +1,7 @@
 //
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Kusto.Language.Symbols;
@@ -40,9 +41,14 @@ internal partial class IRTranslator
 
         // Translate the subquery with the intermediate schema (input columns, with expanded columns retyped to their
         // element type) as the row scope, so the subquery's column references resolve against the expanded rows.
+        // An ALIASED expression (`mv-apply p = parse_json(Col) on (...)`) introduces a name that is not an input
+        // column, so the intermediate scope is the input columns (expanded ones retyped) PLUS those new names —
+        // otherwise the subquery cannot bind them.
         var expandByName = columns.ToDictionary(c => c.ColumnSymbol.Name, c => c.ColumnSymbol);
+        var inputNames = inputScope.Columns.Select(c => c.Name).ToHashSet(StringComparer.Ordinal);
         var interColumns = inputScope.Columns
             .Select(c => expandByName.TryGetValue(c.Name, out var ec) ? ec : c)
+            .Concat(columns.Select(c => c.ColumnSymbol).Where(cs => !inputNames.Contains(cs.Name)))
             .ToArray();
 
         var oldRowScope = _rowScope;

--- a/libraries/KustoLoco.Core/KustoQueryContext.cs
+++ b/libraries/KustoLoco.Core/KustoQueryContext.cs
@@ -173,6 +173,18 @@ public class KustoQueryContext
     }
 
     /// <summary>
+    ///     Injects the resolver used to materialize <c>externaldata (...) [uris]</c>. The engine performs no network
+    ///     or file access of its own and registers no default, so <c>externaldata</c> fails loudly until a host opts
+    ///     in with a bounded, allow-listed implementation. Equivalent to
+    ///     <see cref="AddProvider{T}"/> for <see cref="IExternalDataResolver"/>.
+    /// </summary>
+    public KustoQueryContext SetExternalDataResolver(IExternalDataResolver resolver)
+    {
+        _providers.Set(resolver);
+        return this;
+    }
+
+    /// <summary>
     ///     Runs a query and evaluates the result in order to get an accurate benchmark
     /// </summary>
     public int BenchmarkQuery(string query)

--- a/libraries/KustoLoco.Core/KustoQueryContext.cs
+++ b/libraries/KustoLoco.Core/KustoQueryContext.cs
@@ -34,6 +34,7 @@ public class KustoQueryContext
 {
     
     private Dictionary<FunctionSymbol, ScalarFunctionInfo> _additionalFunctions = [];
+    private readonly ProviderRegistry _providers = new();
     private IKustoConsole _debugConsole = new SystemConsole();
 
     private IKustoQueryContextTableLoader _lazyTableLoader = new NullTableLoader();
@@ -162,11 +163,22 @@ public class KustoQueryContext
     }
 
     /// <summary>
+    ///     Registers a host-supplied provider (for example an IGeoIpProvider) that context-aware scalar functions read
+    ///     at evaluation time. Absent providers leave their functions returning null.
+    /// </summary>
+    public KustoQueryContext AddProvider<T>(T provider) where T : class
+    {
+        _providers.Set(provider);
+        return this;
+    }
+
+    /// <summary>
     ///     Runs a query and evaluates the result in order to get an accurate benchmark
     /// </summary>
     public int BenchmarkQuery(string query)
     {
         var engine = new BabyKustoEngine(new SystemConsole(),_settings);
+        engine.UseProviders(_providers);
         var res = engine.Evaluate(_tables, query);
         return res.RowCount;
     }
@@ -183,6 +195,7 @@ public class KustoQueryContext
         var watch = Stopwatch.StartNew();
         var engine = new BabyKustoEngine(_debugConsole,_settings);
         engine.AddAdditionalFunctions(_additionalFunctions);
+        engine.UseProviders(_providers);
         //handling for "special" commands
         if (query.Trim() == ".tables")
             return CreateTableList(query, false);

--- a/libraries/KustoLoco.Core/KustoQueryContext.cs
+++ b/libraries/KustoLoco.Core/KustoQueryContext.cs
@@ -353,6 +353,17 @@ public class KustoQueryContext
                 if (op is Expression { RawResultType: TableSymbol } e &&
                     op.Kind.ToString() == "NameReference")
                     tables.Add(e.RawResultType.Name);
+
+                // The lookup table named as the first argument of `evaluate ipv4_lookup(<Table>, ...)` is not caught
+                // by the walk above: when it is demand-loaded its name is still unresolved at analyze time — the
+                // loader supplies the schema only AFTER this list is computed — so its RawResultType is an error
+                // symbol rather than a TableSymbol. Discover it syntactically by identifier, otherwise the loader is
+                // never asked for it and the query fails to bind.
+                if (op is EvaluateOperator { FunctionCall: { } call } &&
+                    string.Equals(call.Name?.SimpleName, "ipv4_lookup", StringComparison.OrdinalIgnoreCase) &&
+                    call.ArgumentList?.Expressions is { Count: > 0 } callArgs &&
+                    callArgs[0].Element is NameReference lookupTableName)
+                    tables.Add(lookupTableName.SimpleName);
             });
         //special case handling for when query is _only_ a table name without any operators
         if (!tables.Any() && query.Tokenize().Length == 1) tables.Add(query.Trim());

--- a/test/BasicTests/BagFunctionTests.cs
+++ b/test/BasicTests/BagFunctionTests.cs
@@ -1,0 +1,40 @@
+using AwesomeAssertions;
+
+namespace BasicTests;
+
+[TestClass]
+public class BagFunctionTests : TestMethods
+{
+    [TestMethod]
+    public async Task BagHasKey_Present() =>
+        (await LastLineOfResult("print bag_has_key(dynamic({\"a\":1,\"b\":2}), 'a')")).Should().Be("True");
+
+    [TestMethod]
+    public async Task BagHasKey_Absent() =>
+        (await LastLineOfResult("print bag_has_key(dynamic({\"a\":1,\"b\":2}), 'z')")).Should().Be("False");
+
+    [TestMethod]
+    public async Task BagRemoveKeys() =>
+        (await SquashedLastLineOfResult("print bag_remove_keys(dynamic({\"a\":1,\"b\":2,\"c\":3}), dynamic([\"a\",\"c\"]))"))
+            .Should().Be("{\"b\":2}");
+
+    [TestMethod]
+    public async Task BagSetKey_AddNew() =>
+        (await SquashedLastLineOfResult("print bag_set_key(dynamic({\"a\":1}), 'b', 2)"))
+            .Should().Be("{\"a\":1,\"b\":2}");
+
+    [TestMethod]
+    public async Task BagSetKey_Overwrite() =>
+        (await SquashedLastLineOfResult("print bag_set_key(dynamic({\"a\":1}), 'a', 5)"))
+            .Should().Be("{\"a\":5}");
+
+    [TestMethod]
+    public async Task BagSetKey_StringValue() =>
+        (await SquashedLastLineOfResult("print bag_set_key(dynamic({\"a\":1}), 'b', 'x')"))
+            .Should().Be("{\"a\":1,\"b\":\"x\"}");
+
+    [TestMethod]
+    public async Task BagZip() =>
+        (await SquashedLastLineOfResult("print bag_zip(dynamic([\"a\",\"b\",\"c\"]), dynamic([1,2,3]))"))
+            .Should().Be("{\"a\":1,\"b\":2,\"c\":3}");
+}

--- a/test/BasicTests/DynamicSetFunctionTests.cs
+++ b/test/BasicTests/DynamicSetFunctionTests.cs
@@ -1,0 +1,64 @@
+using AwesomeAssertions;
+
+namespace BasicTests;
+
+[TestClass]
+public class DynamicSetFunctionTests : TestMethods
+{
+    [TestMethod]
+    public async Task SetHasElement_Present()
+    {
+        var query = "print set_has_element(dynamic([1,2,3]), 2)";
+        var result = await LastLineOfResult(query);
+        result.Should().Be("True");
+    }
+
+    [TestMethod]
+    public async Task SetHasElement_Absent()
+    {
+        var query = "print set_has_element(dynamic([1,2,3]), 5)";
+        var result = await LastLineOfResult(query);
+        result.Should().Be("False");
+    }
+
+    [TestMethod]
+    public async Task SetHasElement_String()
+    {
+        var query = "print set_has_element(dynamic([\"a\",\"b\",\"c\"]), \"b\")";
+        var result = await LastLineOfResult(query);
+        result.Should().Be("True");
+    }
+
+    [TestMethod]
+    public async Task SetHasElement_StringAbsent()
+    {
+        var query = "print set_has_element(dynamic([\"a\",\"b\",\"c\"]), \"z\")";
+        var result = await LastLineOfResult(query);
+        result.Should().Be("False");
+    }
+
+    [TestMethod]
+    public async Task SetHasElement_NotAnArray_IsNull()
+    {
+        // set_has_element over a non-array dynamic yields null (renders as empty).
+        var query = "print set_has_element(dynamic({\"a\":1}), 1)";
+        var result = await LastLineOfResult(query);
+        result.Should().Be("");
+    }
+
+    [TestMethod]
+    public async Task BagKeys_Object()
+    {
+        var query = "print tostring(bag_keys(dynamic({\"a\":1,\"b\":2,\"c\":3})))";
+        var result = await LastLineOfResult(query);
+        result.Should().Be("[\"a\",\"b\",\"c\"]");
+    }
+
+    [TestMethod]
+    public async Task BagKeys_NotAnObject_IsNull()
+    {
+        var query = "print bag_keys(dynamic([1,2,3]))";
+        var result = await LastLineOfResult(query);
+        result.Should().Be("");
+    }
+}

--- a/test/BasicTests/ExternalDataOperatorTests.cs
+++ b/test/BasicTests/ExternalDataOperatorTests.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using System.Linq;
+using AwesomeAssertions;
+using KustoLoco.Core;
+using NotNullStrings;
+
+namespace BasicTests;
+
+[TestClass]
+public class ExternalDataOperatorTests : TestMethods
+{
+    private sealed class StubResolver : IExternalDataResolver
+    {
+        public IReadOnlyList<object?[]>? Resolve(ExternalDataRequest request) =>
+            new object?[][]
+            {
+                new object?[] { "alice", "bob" }, // name column
+                new object?[] { 30L, 40L },       // age column
+            };
+    }
+
+    private static string LastLine(KustoQueryResult result) =>
+        result.GetRow(result.RowCount - 1).Select(KustoFormatter.ObjectToKustoString).JoinString();
+
+    [TestMethod]
+    public async Task ExternalData_WithResolver_ProducesRows()
+    {
+        var context = CreateContext();
+        context.AddProvider<IExternalDataResolver>(new StubResolver());
+        var result = await context.RunQuery(
+            "externaldata(name:string, age:long)['https://example.com/data.csv'] with(format='csv')");
+        result.RowCount.Should().Be(2);
+        LastLine(result).Should().Contain("bob").And.Contain("40");
+    }
+
+    [TestMethod]
+    public async Task ExternalData_WithResolver_CanBePipelined()
+    {
+        var context = CreateContext();
+        context.AddProvider<IExternalDataResolver>(new StubResolver());
+        var result = await context.RunQuery(
+            "externaldata(name:string, age:long)['https://example.com/data.csv'] with(format='csv') " +
+            "| where age > 35 | project name");
+        result.RowCount.Should().Be(1);
+        LastLine(result).Should().Be("bob");
+    }
+
+    [TestMethod]
+    public async Task ExternalData_NoResolver_FailsClosedEmpty()
+    {
+        var context = CreateContext(); // no resolver registered
+        var result = await context.RunQuery(
+            "externaldata(name:string, age:long)['https://example.com/data.csv'] with(format='csv')");
+        result.RowCount.Should().Be(0);
+    }
+}

--- a/test/BasicTests/ExternalDataOperatorTests.cs
+++ b/test/BasicTests/ExternalDataOperatorTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using AwesomeAssertions;
@@ -9,24 +10,25 @@ namespace BasicTests;
 [TestClass]
 public class ExternalDataOperatorTests : TestMethods
 {
+    /// <summary>A host resolver that serves canned text, exercising the real path: the host returns delimited rows,
+    /// the engine types them per the declared schema.</summary>
     private sealed class StubResolver : IExternalDataResolver
     {
-        public IReadOnlyList<object?[]>? Resolve(ExternalDataRequest request) =>
-            new object?[][]
-            {
-                new object?[] { "alice", "bob" }, // name column
-                new object?[] { 30L, 40L },       // age column
-            };
+        private readonly string _content;
+        public StubResolver(string content) => _content = content;
+        public IReadOnlyList<IReadOnlyList<string>> ResolveRows(string uri, string format) =>
+            DelimitedTextParser.Parse(_content, DelimitedTextParser.DelimiterFor(format));
     }
+
+    private const string Csv = "alice,30\nbob,40\n";
 
     private static string LastLine(KustoQueryResult result) =>
         result.GetRow(result.RowCount - 1).Select(KustoFormatter.ObjectToKustoString).JoinString();
 
     [TestMethod]
-    public async Task ExternalData_WithResolver_ProducesRows()
+    public async Task ExternalData_WithResolver_ProducesTypedRows()
     {
-        var context = CreateContext();
-        context.AddProvider<IExternalDataResolver>(new StubResolver());
+        var context = CreateContext().SetExternalDataResolver(new StubResolver(Csv));
         var result = await context.RunQuery(
             "externaldata(name:string, age:long)['https://example.com/data.csv'] with(format='csv')");
         result.RowCount.Should().Be(2);
@@ -36,8 +38,8 @@ public class ExternalDataOperatorTests : TestMethods
     [TestMethod]
     public async Task ExternalData_WithResolver_CanBePipelined()
     {
-        var context = CreateContext();
-        context.AddProvider<IExternalDataResolver>(new StubResolver());
+        // 'age' must be a real long for the predicate to work — proof the engine typed the text cells.
+        var context = CreateContext().SetExternalDataResolver(new StubResolver(Csv));
         var result = await context.RunQuery(
             "externaldata(name:string, age:long)['https://example.com/data.csv'] with(format='csv') " +
             "| where age > 35 | project name");
@@ -46,11 +48,40 @@ public class ExternalDataOperatorTests : TestMethods
     }
 
     [TestMethod]
-    public async Task ExternalData_NoResolver_FailsClosedEmpty()
+    public async Task ExternalData_HonoursTheDeclaredFormat()
     {
+        var context = CreateContext().SetExternalDataResolver(new StubResolver("alice\t30\nbob\t40\n"));
+        var result = await context.RunQuery(
+            "externaldata(name:string, age:long)['https://example.com/data.tsv'] with(format='tsv') " +
+            "| where age > 35 | project name");
+        LastLine(result).Should().Be("bob");
+    }
+
+    [TestMethod]
+    public async Task ExternalData_NoResolver_FailsLoud()
+    {
+        // An unreachable list must NEVER look like a clean no-match: with no resolver the query reports an ERROR
+        // (the engine captures query errors into the result) rather than quietly yielding zero rows.
         var context = CreateContext(); // no resolver registered
         var result = await context.RunQuery(
             "externaldata(name:string, age:long)['https://example.com/data.csv'] with(format='csv')");
+        result.Error.Should().NotBeEmpty();
+        result.Error.Should().Contain("IExternalDataResolver");
+    }
+
+    [TestMethod]
+    public async Task ExternalData_ResolverFailure_IsReportedNotSwallowed()
+    {
+        var context = CreateContext().SetExternalDataResolver(new ThrowingResolver());
+        var result = await context.RunQuery(
+            "externaldata(name:string)['https://example.com/data.csv'] with(format='csv')");
+        result.Error.Should().NotBeEmpty();
         result.RowCount.Should().Be(0);
+    }
+
+    private sealed class ThrowingResolver : IExternalDataResolver
+    {
+        public IReadOnlyList<IReadOnlyList<string>> ResolveRows(string uri, string format) =>
+            throw new NotSupportedException("host refuses this URI");
     }
 }

--- a/test/BasicTests/ExtractAllFunctionTests.cs
+++ b/test/BasicTests/ExtractAllFunctionTests.cs
@@ -1,0 +1,31 @@
+using AwesomeAssertions;
+
+namespace BasicTests;
+
+[TestClass]
+public class ExtractAllFunctionTests : TestMethods
+{
+    [TestMethod]
+    public async Task ExtractAll_NoGroups_FullMatches()
+    {
+        var query = "print tostring(extract_all(@'\\d+', 'a1b22c333'))";
+        var result = await LastLineOfResult(query);
+        result.Should().Be("[\"1\",\"22\",\"333\"]");
+    }
+
+    [TestMethod]
+    public async Task ExtractAll_OneGroup()
+    {
+        var query = "print tostring(extract_all(@'(\\d)\\d', '12 34 56'))";
+        var result = await LastLineOfResult(query);
+        result.Should().Be("[\"1\",\"3\",\"5\"]");
+    }
+
+    [TestMethod]
+    public async Task ExtractAll_NoMatch_EmptyArray()
+    {
+        var query = "print tostring(extract_all(@'\\d+', 'abc'))";
+        var result = await LastLineOfResult(query);
+        result.Should().Be("[]");
+    }
+}

--- a/test/BasicTests/GeoInfoFromIpFunctionTests.cs
+++ b/test/BasicTests/GeoInfoFromIpFunctionTests.cs
@@ -1,0 +1,50 @@
+using System.Linq;
+using System.Net;
+using AwesomeAssertions;
+using KustoLoco.Core;
+using NotNullStrings;
+
+namespace BasicTests;
+
+[TestClass]
+public class GeoInfoFromIpFunctionTests : TestMethods
+{
+    private sealed class StubGeoProvider : IGeoIpProvider
+    {
+        public GeoIpInfo? Lookup(IPAddress address) =>
+            address.ToString() == "8.8.8.8"
+                ? new GeoIpInfo("United States", "California", "Mountain View", 37.386, -122.0838)
+                : null;
+    }
+
+    private static string LastLine(KustoQueryResult result) =>
+        result.GetRow(result.RowCount - 1).Select(KustoFormatter.ObjectToKustoString).JoinString();
+
+    [TestMethod]
+    public async Task GeoInfoFromIp_WithProvider_Resolves()
+    {
+        var context = CreateContext();
+        context.AddProvider<IGeoIpProvider>(new StubGeoProvider());
+        var result = await context.RunQuery("print tostring(geo_info_from_ip_address('8.8.8.8'))");
+        var line = LastLine(result);
+        line.Should().Contain("United States");
+        line.Should().Contain("Mountain View");
+    }
+
+    [TestMethod]
+    public async Task GeoInfoFromIp_UnknownAddress_Null()
+    {
+        var context = CreateContext();
+        context.AddProvider<IGeoIpProvider>(new StubGeoProvider());
+        var result = await context.RunQuery("print geo_info_from_ip_address('1.2.3.4')");
+        LastLine(result).Should().Be("<null>");
+    }
+
+    [TestMethod]
+    public async Task GeoInfoFromIp_NoProvider_InertNull()
+    {
+        var context = CreateContext();   // no provider registered -> function stays inert
+        var result = await context.RunQuery("print geo_info_from_ip_address('8.8.8.8')");
+        LastLine(result).Should().Be("<null>");
+    }
+}

--- a/test/BasicTests/Ipv4FormatFunctionTests.cs
+++ b/test/BasicTests/Ipv4FormatFunctionTests.cs
@@ -1,0 +1,35 @@
+using AwesomeAssertions;
+
+namespace BasicTests;
+
+[TestClass]
+public class Ipv4FormatFunctionTests : TestMethods
+{
+    [TestMethod]
+    public async Task FormatIpv4_NoPrefix() =>
+        (await LastLineOfResult("print format_ipv4('192.168.1.255')")).Should().Be("192.168.1.255");
+
+    [TestMethod]
+    public async Task FormatIpv4_Prefix() =>
+        (await LastLineOfResult("print format_ipv4('192.168.1.255', 24)")).Should().Be("192.168.1.0");
+
+    [TestMethod]
+    public async Task FormatIpv4_BadIp_Null() =>
+        (await LastLineOfResult("print format_ipv4('nope', 24)")).Should().Be("<null>");
+
+    [TestMethod]
+    public async Task FormatIpv4Mask() =>
+        (await LastLineOfResult("print format_ipv4_mask('192.168.1.255', 24)")).Should().Be("192.168.1.0/24");
+
+    [TestMethod]
+    public async Task Ipv4NetmaskSuffix_Present() =>
+        (await LastLineOfResult("print ipv4_netmask_suffix('192.168.1.1/24')")).Should().Be("24");
+
+    [TestMethod]
+    public async Task Ipv4NetmaskSuffix_Absent_Is32() =>
+        (await LastLineOfResult("print ipv4_netmask_suffix('192.168.1.1')")).Should().Be("32");
+
+    [TestMethod]
+    public async Task ParseIpv4Mask() =>
+        (await LastLineOfResult("print parse_ipv4_mask('192.168.1.255', 24)")).Should().Be("3232235776");
+}

--- a/test/BasicTests/Ipv4FunctionTests.cs
+++ b/test/BasicTests/Ipv4FunctionTests.cs
@@ -1,0 +1,51 @@
+using AwesomeAssertions;
+
+namespace BasicTests;
+
+[TestClass]
+public class Ipv4FunctionTests : TestMethods
+{
+    [TestMethod]
+    public async Task Ipv4IsInRange_In() =>
+        (await LastLineOfResult("print ipv4_is_in_range('192.168.1.6', '192.168.1.0/24')")).Should().Be("True");
+
+    [TestMethod]
+    public async Task Ipv4IsInRange_Out() =>
+        (await LastLineOfResult("print ipv4_is_in_range('192.168.2.6', '192.168.1.0/24')")).Should().Be("False");
+
+    [TestMethod]
+    public async Task Ipv4IsInRange_BadIp_Null() =>
+        (await LastLineOfResult("print ipv4_is_in_range('not-an-ip', '192.168.1.0/24')")).Should().Be("<null>");
+
+    [TestMethod]
+    public async Task Ipv4Compare_Equal() =>
+        (await LastLineOfResult("print ipv4_compare('192.168.1.1', '192.168.1.1')")).Should().Be("0");
+
+    [TestMethod]
+    public async Task Ipv4Compare_Less() =>
+        (await LastLineOfResult("print ipv4_compare('192.168.1.1', '192.168.1.2')")).Should().Be("-1");
+
+    [TestMethod]
+    public async Task Ipv4Compare_PrefixMasksDifference() =>
+        (await LastLineOfResult("print ipv4_compare('192.168.1.1', '192.168.1.2', 24)")).Should().Be("0");
+
+    [TestMethod]
+    public async Task Ipv4IsMatch_SamePrefix() =>
+        (await LastLineOfResult("print ipv4_is_match('192.168.1.1', '192.168.1.2', 24)")).Should().Be("True");
+
+    [TestMethod]
+    public async Task Ipv4IsMatch_DifferentPrefix() =>
+        (await LastLineOfResult("print ipv4_is_match('192.168.1.1', '192.168.2.1', 24)")).Should().Be("False");
+
+    [TestMethod]
+    public async Task Ipv4IsInAnyRange_MatchCidr() =>
+        (await LastLineOfResult("print ipv4_is_in_any_range('10.0.0.5', dynamic([\"192.168.0.0/16\",\"10.0.0.0/8\"]))")).Should().Be("True");
+
+    [TestMethod]
+    public async Task Ipv4IsInAnyRange_MatchBareAddress() =>
+        (await LastLineOfResult("print ipv4_is_in_any_range('192.168.1.6', dynamic([\"192.168.1.6\",\"10.0.0.0/8\"]))")).Should().Be("True");
+
+    [TestMethod]
+    public async Task Ipv4IsInAnyRange_NoMatch() =>
+        (await LastLineOfResult("print ipv4_is_in_any_range('172.16.0.1', dynamic([\"192.168.0.0/16\",\"10.0.0.0/8\"]))")).Should().Be("False");
+}

--- a/test/BasicTests/Ipv4LookupOperatorTests.cs
+++ b/test/BasicTests/Ipv4LookupOperatorTests.cs
@@ -56,6 +56,24 @@ public class Ipv4LookupOperatorTests : TestMethods
     }
 
     [TestMethod]
+    public async Task Ipv4Lookup_ThenFilterAndSummarizeIntoSets()
+    {
+        // The shape a reputation rule actually forms: enrich by CIDR, filter on an appended column, then aggregate
+        // both source and appended columns into sets per actor.
+        var query =
+            "let Ranges = datatable(Cidr:string, NetworkTrust:string)" +
+            "['10.0.0.0/8','tor', '192.168.0.0/16','vpn', '172.16.0.0/12','hosting'];" +
+            "datatable(Actor:string, IPAddress:string)" +
+            "['a@x','10.1.1.1', 'a@x','192.168.5.5', 'b@x','8.8.8.8'] " +
+            "| evaluate ipv4_lookup(Ranges, IPAddress, Cidr) " +
+            "| where NetworkTrust in ('tor','vpn','hosting') " +
+            "| summarize Ips = make_set(IPAddress), Trusts = make_set(NetworkTrust) by Actor";
+        var result = await SquashedLastLineOfResult(query);
+        // 'a@x' matched two different anonymizer classes; 'b@x' matched nothing and is absent.
+        result.Should().Contain("tor").And.Contain("vpn");
+    }
+
+    [TestMethod]
     public async Task Ipv4Lookup_ExtraKeysNarrowTheMatch()
     {
         // ExtraKeys are columns in BOTH tables that must also match by equality, so an IP inside the CIDR whose

--- a/test/BasicTests/Ipv4LookupOperatorTests.cs
+++ b/test/BasicTests/Ipv4LookupOperatorTests.cs
@@ -30,4 +30,42 @@ public class Ipv4LookupOperatorTests : TestMethods
         var result = await CreateContext().RunQuery(query);
         result.RowCount.Should().Be(0);
     }
+
+    [TestMethod]
+    public async Task Ipv4Lookup_ReturnUnmatched_Positional_KeepsUnmatchedRows()
+    {
+        // The trailing return_unmatched flag written positionally: unmatched rows are kept with null lookup columns.
+        var query = Lookup +
+            "datatable(SourceIP:string)['10.1.2.3', '8.8.8.8'] " +
+            "| evaluate ipv4_lookup(LookupTable, SourceIP, Network, true)";
+        var result = await CreateContext().RunQuery(query);
+        result.RowCount.Should().Be(2);
+        var rendered = await ResultAsString(query, ";");
+        rendered.Should().Contain("US").And.Contain("8.8.8.8");
+    }
+
+    [TestMethod]
+    public async Task Ipv4Lookup_ReturnUnmatched_Named_KeepsUnmatchedRows()
+    {
+        // The documented named form: evaluate ipv4_lookup(.., return_unmatched = true).
+        var query = Lookup +
+            "datatable(SourceIP:string)['10.1.2.3', '8.8.8.8'] " +
+            "| evaluate ipv4_lookup(LookupTable, SourceIP, Network, return_unmatched = true)";
+        var result = await CreateContext().RunQuery(query);
+        result.RowCount.Should().Be(2);
+    }
+
+    [TestMethod]
+    public async Task Ipv4Lookup_ExtraKeysNarrowTheMatch()
+    {
+        // ExtraKeys are columns in BOTH tables that must also match by equality, so an IP inside the CIDR whose
+        // Env differs is NOT joined.
+        var query =
+            "let Ranges = datatable(Network:string, Env:string, Label:string)" +
+            "['10.0.0.0/8','prod','ProdNet', '10.0.0.0/8','test','TestNet'];" +
+            "datatable(SourceIP:string, Env:string)['10.1.2.3','test'] " +
+            "| evaluate ipv4_lookup(Ranges, SourceIP, Network, Env)";
+        var result = await ResultAsString(query, ";");
+        result.Should().Contain("TestNet").And.NotContain("ProdNet");
+    }
 }

--- a/test/BasicTests/Ipv4LookupOperatorTests.cs
+++ b/test/BasicTests/Ipv4LookupOperatorTests.cs
@@ -1,0 +1,33 @@
+using AwesomeAssertions;
+
+namespace BasicTests;
+
+[TestClass]
+public class Ipv4LookupOperatorTests : TestMethods
+{
+    private const string Lookup =
+        "let LookupTable = datatable(Network:string, Country:string)" +
+        "['10.0.0.0/8','US', '192.168.0.0/16','LAN'];";
+
+    [TestMethod]
+    public async Task Ipv4Lookup_MatchesCidrAndAppendsColumns()
+    {
+        var query = Lookup +
+            "datatable(SourceIP:string)['10.1.2.3', '192.168.5.5', '8.8.8.8'] " +
+            "| evaluate ipv4_lookup(LookupTable, SourceIP, Network)";
+        var result = await ResultAsString(query, ";");
+        // 10.1.2.3 -> US, 192.168.5.5 -> LAN; 8.8.8.8 matches nothing and is dropped.
+        result.Should().Contain("US").And.Contain("LAN");
+        result.Should().NotContain("8.8.8.8");
+    }
+
+    [TestMethod]
+    public async Task Ipv4Lookup_UnmatchedRowsDropped()
+    {
+        var query = Lookup +
+            "datatable(SourceIP:string)['8.8.8.8', '1.1.1.1'] " +
+            "| evaluate ipv4_lookup(LookupTable, SourceIP, Network)";
+        var result = await CreateContext().RunQuery(query);
+        result.RowCount.Should().Be(0);
+    }
+}

--- a/test/BasicTests/Ipv4LookupOperatorTests.cs
+++ b/test/BasicTests/Ipv4LookupOperatorTests.cs
@@ -1,3 +1,7 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using KustoLoco.Core;
 using AwesomeAssertions;
 
 namespace BasicTests;
@@ -53,6 +57,37 @@ public class Ipv4LookupOperatorTests : TestMethods
             "| evaluate ipv4_lookup(LookupTable, SourceIP, Network, return_unmatched = true)";
         var result = await CreateContext().RunQuery(query);
         result.RowCount.Should().Be(2);
+    }
+
+    /// <summary>Serves the lookup table on demand, the way a host supplies reference data.</summary>
+    private sealed class OnDemandRanges : IKustoQueryContextTableLoader
+    {
+        public Task LoadTablesAsync(KustoQueryContext context, IReadOnlyCollection<string> tableNames)
+        {
+            if (tableNames.Contains("Ranges"))
+            {
+                var t = new System.Data.DataTable("Ranges");
+                t.Columns.Add("Cidr", typeof(string));
+                t.Columns.Add("Label", typeof(string));
+                t.Rows.Add("10.0.0.0/8", "corp");
+                context.AddTableFromDataTable(t, "Ranges");
+            }
+            return Task.CompletedTask;
+        }
+    }
+
+    [TestMethod]
+    public async Task Ipv4Lookup_ResolvesADemandLoadedLookupTable()
+    {
+        // The lookup table is supplied by a table loader, so at analyze time its name is UNRESOLVED — the schema
+        // arrives only after the engine has decided which tables to ask for. The plugin's table argument must
+        // therefore be discovered syntactically, or the query never gets its table and fails to bind.
+        var context = new KustoQueryContext();
+        context.SetTableLoader(new OnDemandRanges());
+        var result = await context.RunQuery(
+            "datatable(SourceIP:string)['10.1.2.3'] | evaluate ipv4_lookup(Ranges, SourceIP, Cidr)");
+        result.Error.Should().BeEmpty();
+        result.RowCount.Should().Be(1);
     }
 
     [TestMethod]

--- a/test/BasicTests/Ipv4RangeHasFunctionTests.cs
+++ b/test/BasicTests/Ipv4RangeHasFunctionTests.cs
@@ -1,0 +1,42 @@
+using AwesomeAssertions;
+
+namespace BasicTests;
+
+[TestClass]
+public class Ipv4RangeHasFunctionTests : TestMethods
+{
+    [TestMethod]
+    public async Task RangeToCidr_AlignedBlock() =>
+        (await SquashedLastLineOfResult("print ipv4_range_to_cidr_list('192.168.1.0', '192.168.1.255')"))
+            .Should().Be("[\"192.168.1.0/24\"]");
+
+    [TestMethod]
+    public async Task RangeToCidr_SmallBlock() =>
+        (await SquashedLastLineOfResult("print ipv4_range_to_cidr_list('10.0.0.0', '10.0.0.3')"))
+            .Should().Be("[\"10.0.0.0/30\"]");
+
+    [TestMethod]
+    public async Task RangeToCidr_UnalignedSplit() =>
+        (await SquashedLastLineOfResult("print ipv4_range_to_cidr_list('10.0.0.1', '10.0.0.2')"))
+            .Should().Be("[\"10.0.0.1/32\",\"10.0.0.2/32\"]");
+
+    [TestMethod]
+    public async Task HasIpv4_Delimited() =>
+        (await LastLineOfResult("print has_ipv4('Source address 10.1.2.3 flagged', '10.1.2.3')")).Should().Be("True");
+
+    [TestMethod]
+    public async Task HasIpv4_NotDelimited_False() =>
+        (await LastLineOfResult("print has_ipv4('address 110.1.2.3 here', '10.1.2.3')")).Should().Be("False");
+
+    [TestMethod]
+    public async Task HasIpv4Prefix() =>
+        (await LastLineOfResult("print has_ipv4_prefix('conn to 10.1.2.3 open', '10.1.')")).Should().Be("True");
+
+    [TestMethod]
+    public async Task HasAnyIpv4_Match() =>
+        (await LastLineOfResult("print has_any_ipv4('hit 10.0.0.5 now', dynamic([\"192.168.0.1\",\"10.0.0.5\"]))")).Should().Be("True");
+
+    [TestMethod]
+    public async Task HasAnyIpv4Prefix_Match() =>
+        (await LastLineOfResult("print has_any_ipv4_prefix('hit 10.0.0.5 now', dynamic([\"192.168.\",\"10.0.\"]))")).Should().Be("True");
+}

--- a/test/BasicTests/MakeSeriesOperatorTests.cs
+++ b/test/BasicTests/MakeSeriesOperatorTests.cs
@@ -24,6 +24,21 @@ public class MakeSeriesOperatorTests : TestMethods
     }
 
     [TestMethod]
+    public async Task MakeSeries_DateTimeAxis_BinsOnTheUtcInstant()
+    {
+        // The axis values and the from/to literals must be compared as the same instant. If a datetime is taken at
+        // face value rather than as UTC, a host in a non-UTC zone shifts one side against the other and every row
+        // lands outside the range — a dense series of zeros that looks like "no data" rather than an error.
+        var q = "datatable(t:datetime, u:string)" +
+                "[datetime(2026-07-29T00:00:00Z),'a', datetime(2026-07-29T00:30:00Z),'a', datetime(2026-07-29T02:00:00Z),'a']" +
+                "| make-series c=count() default=0 on t " +
+                "from datetime(2026-07-29T00:00:00Z) to datetime(2026-07-29T03:00:00Z) step 1h by u";
+        var result = await SquashedLastLineOfResult(q);
+        result.Should().Contain("[2,0,1]");                       // two in the first hour, none in the second, one in the third
+        result.Should().Contain("2026-07-29T00:00:00.0000000Z");  // and the axis starts where the range says it does
+    }
+
+    [TestMethod]
     public async Task MakeSeries_NonMultipleRange_HasCorrectPointCount()
     {
         // from 0 to 11 step 2 -> 0,2,4,6,8,10 (11 non-inclusive) = 6 points. A floor() count would give only 5.

--- a/test/BasicTests/MakeSeriesOperatorTests.cs
+++ b/test/BasicTests/MakeSeriesOperatorTests.cs
@@ -1,0 +1,45 @@
+using AwesomeAssertions;
+
+namespace BasicTests;
+
+[TestClass]
+public class MakeSeriesOperatorTests : TestMethods
+{
+    [TestMethod]
+    public async Task MakeSeries_SumOverNumericAxis()
+    {
+        var query = "datatable(x:long, val:long)[1,10, 2,20, 3,30] " +
+                    "| make-series s=sum(val) default=0 on x from 1 to 4 step 1";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Contain("[10,20,30]");
+    }
+
+    [TestMethod]
+    public async Task MakeSeries_GapFillsEmptyBucketsWithDefault()
+    {
+        // x has 1 and 3 but not 2 -> the middle bucket is empty and gap-filled with 0.
+        var query = "datatable(x:long, val:long)[1,10, 3,30] " +
+                    "| make-series s=sum(val) default=0 on x from 1 to 4 step 1";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Contain("[10,0,30]");
+    }
+
+    [TestMethod]
+    public async Task MakeSeries_ByGroup()
+    {
+        var query = "datatable(g:string, x:long, val:long)['a',1,10, 'a',2,20, 'b',1,100] " +
+                    "| make-series s=sum(val) default=0 on x from 1 to 3 step 1 by g";
+        // Last group is 'b': x=1 -> 100, x=2 empty -> gap-filled 0.
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Contain("b").And.Contain("[100,0]");
+    }
+
+    [TestMethod]
+    public async Task MakeSeries_CountAggregate()
+    {
+        var query = "datatable(x:long)[1, 1, 2] " +
+                    "| make-series c=count() default=0 on x from 1 to 3 step 1";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Contain("[2,1]");
+    }
+}

--- a/test/BasicTests/MakeSeriesOperatorTests.cs
+++ b/test/BasicTests/MakeSeriesOperatorTests.cs
@@ -42,6 +42,16 @@ public class MakeSeriesOperatorTests : TestMethods
     }
 
     [TestMethod]
+    public async Task MakeSeries_InRange_StopIsInclusive()
+    {
+        // The 'in range(start, stop, step)' syntax has an INCLUSIVE stop, so range(0,10,2) -> 0,2,4,6,8,10 = 6 points
+        // (whereas 'from 0 to 10 step 2' would be 5). Exercises the StopInclusive path.
+        var q = "datatable(x:long)[0,2,4,6,8,10] | make-series c=count() on x in range(0, 10, 2)";
+        var result = await SquashedLastLineOfResult(q);
+        result.Should().Contain("[1,1,1,1,1,1]");
+    }
+
+    [TestMethod]
     public async Task MakeSeries_SumOverNumericAxis()
     {
         var query = "datatable(x:long, val:long)[1,10, 2,20, 3,30] " +

--- a/test/BasicTests/MakeSeriesOperatorTests.cs
+++ b/test/BasicTests/MakeSeriesOperatorTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using AwesomeAssertions;
 
 namespace BasicTests;
@@ -5,6 +6,41 @@ namespace BasicTests;
 [TestClass]
 public class MakeSeriesOperatorTests : TestMethods
 {
+    [TestMethod]
+    public async Task MakeSeries_ColumnOrder_AggregateFirst_AxisLast_DateTimeExact()
+    {
+        // Kusto schema order is [aggregates..., axis]; the axis is the LAST column. The datetime axis must be exact
+        // (computed in ticks, not double), and with no 'default=' the empty Jan-02 bin fills with 0.
+        var q = "datatable(t:datetime, v:long)[datetime(2017-01-01),10, datetime(2017-01-03),30] " +
+                "| make-series s=sum(v) on t from datetime(2017-01-01) to datetime(2017-01-04) step 1d";
+        var result = await Result(q);
+        result.ColumnDefinitions().Select(c => c.Name).Should().Equal("s", "t");
+        var row = result.GetRow(0).ToArray();
+        Squash(row[0]?.ToString() ?? "").Should().Be("[10,0,30]");           // aggregate series, default-0 gap fill
+        var axis = row[1]?.ToString() ?? "";
+        axis.Should().Contain("2017-01-01T00:00:00.0000000Z")
+            .And.Contain("2017-01-03T00:00:00.0000000Z")
+            .And.NotContain("2017-01-04");                                   // 'to' is non-inclusive
+    }
+
+    [TestMethod]
+    public async Task MakeSeries_NonMultipleRange_HasCorrectPointCount()
+    {
+        // from 0 to 11 step 2 -> 0,2,4,6,8,10 (11 non-inclusive) = 6 points. A floor() count would give only 5.
+        var q = "datatable(x:long)[0,2,4,6,8,10] | make-series c=count() on x from 0 to 11 step 2";
+        var result = await SquashedLastLineOfResult(q);
+        result.Should().Contain("[1,1,1,1,1,1]");
+    }
+
+    [TestMethod]
+    public async Task MakeSeries_NoExplicitDefault_FillsZeroNotNull()
+    {
+        // No 'default=' clause: ADX fills empty bins with a typed 0, not null.
+        var q = "datatable(x:long)[1,3] | make-series c=count() on x from 1 to 4 step 1";
+        var result = await SquashedLastLineOfResult(q);
+        result.Should().Contain("[1,0,1]").And.NotContain("null");
+    }
+
     [TestMethod]
     public async Task MakeSeries_SumOverNumericAxis()
     {

--- a/test/BasicTests/MvApplyOperatorTests.cs
+++ b/test/BasicTests/MvApplyOperatorTests.cs
@@ -55,6 +55,22 @@ public class MvApplyOperatorTests : TestMethods
     }
 
     [TestMethod]
+    public async Task MvApply_EmptyArrayProducesNoRowsForThatRecord()
+    {
+        // mv-apply is a lateral join: a record whose array is empty contributes nothing. (mv-expand differs — it
+        // keeps the record with a null.) Running the subquery over an empty expansion would resurrect the record,
+        // because an aggregate over an empty table still emits a row.
+        var query =
+            "datatable(id:long, payload:string)[1, '[]', 2, '[1,2]'] " +
+            "| mv-apply p = parse_json(payload) to typeof(long) on (summarize s=sum(p)) " +
+            "| project id";
+        var result = await CreateContext().RunQuery(query);
+        result.RowCount.Should().Be(1);            // only id=2 survives
+        var rendered = await ResultAsString(query, ";");
+        rendered.Should().Contain("2").And.NotContain("1;");
+    }
+
+    [TestMethod]
     public async Task MvApply_BagThenReadBackAField()
     {
         // The full real-world round trip: fold name/value pairs into a bag, then read a field back out of it —

--- a/test/BasicTests/MvApplyOperatorTests.cs
+++ b/test/BasicTests/MvApplyOperatorTests.cs
@@ -55,6 +55,32 @@ public class MvApplyOperatorTests : TestMethods
     }
 
     [TestMethod]
+    public async Task MvApply_BagThenReadBackAField()
+    {
+        // The full real-world round trip: fold name/value pairs into a bag, then read a field back out of it —
+        // which is what makes the idiom worth using at all.
+        var query =
+            "datatable(id:long, Parameters:string)" +
+            "[1, '[{\"Name\":\"ForwardTo\",\"Value\":\"evil@x.com\"},{\"Name\":\"Enabled\",\"Value\":\"True\"}]'] " +
+            "| mv-apply p = parse_json(Parameters) on ( summarize P = make_bag(bag_pack(tolower(tostring(p.Name)), p.Value)) ) " +
+            "| extend Target = tostring(P['forwardto']) " +
+            "| project Target";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Contain("evil@x.com");
+    }
+
+    [TestMethod]
+    public async Task MvApply_ExpansionFeedsMakeSet()
+    {
+        // mv-apply feeding make_set — the aggregate most used by real rules.
+        var query =
+            "datatable(id:long, payload:string)[1, '[\"a\",\"b\",\"a\"]'] " +
+            "| mv-apply p = parse_json(payload) on ( summarize S = make_set(tostring(p)) )";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Contain("a").And.Contain("b");
+    }
+
+    [TestMethod]
     public async Task MvApply_SourceColumnSurvives()
     {
         // The source 'id' survives the subquery and is associated with each output row.

--- a/test/BasicTests/MvApplyOperatorTests.cs
+++ b/test/BasicTests/MvApplyOperatorTests.cs
@@ -30,6 +30,31 @@ public class MvApplyOperatorTests : TestMethods
     }
 
     [TestMethod]
+    public async Task MvApply_ExpandsAnAliasedExpression()
+    {
+        // The expanded item may be an ALIASED EXPRESSION rather than an existing column — the common real-world
+        // form, e.g. mv-apply p = parse_json(Col) on (...). 'p' is not in the input schema, so the operator must
+        // evaluate the expression rather than resolve the name against the source row.
+        var query =
+            "datatable(id:long, payload:string)[1, '[1,2,3]'] " +
+            "| mv-apply p = parse_json(payload) to typeof(long) on (summarize s=sum(p))";
+        var result = await ResultAsString(query, ";");
+        result.Should().Contain("6");
+    }
+
+    [TestMethod]
+    public async Task MvApply_AliasedExpression_NameValuePairsIntoABag()
+    {
+        // The name/value-pair idiom: expand a dynamic array of {Name,Value} objects and fold it into one bag per
+        // source row. Exercises an aliased expression + dynamic member access + an aggregate over the expansion.
+        var query =
+            "datatable(id:long, Parameters:string)[1, '[{\"Name\":\"Alpha\",\"Value\":\"1\"},{\"Name\":\"Beta\",\"Value\":\"2\"}]'] " +
+            "| mv-apply p = parse_json(Parameters) on ( summarize P = make_bag(bag_pack(tolower(tostring(p.Name)), p.Value)) )";
+        var result = await SquashedLastLineOfResult(query);
+        result.Should().Contain("alpha").And.Contain("beta");
+    }
+
+    [TestMethod]
     public async Task MvApply_SourceColumnSurvives()
     {
         // The source 'id' survives the subquery and is associated with each output row.

--- a/test/BasicTests/MvApplyOperatorTests.cs
+++ b/test/BasicTests/MvApplyOperatorTests.cs
@@ -1,0 +1,42 @@
+using AwesomeAssertions;
+
+namespace BasicTests;
+
+[TestClass]
+public class MvApplyOperatorTests : TestMethods
+{
+    [TestMethod]
+    public async Task MvApply_SummarizePerSourceRow()
+    {
+        // Each source row's array is summed independently: [1,2,3]->6, [10,20]->30.
+        var query =
+            "datatable(id:long, vals:dynamic)[1, dynamic([1,2,3]), 2, dynamic([10,20])] " +
+            "| mv-apply vals to typeof(long) on (summarize s=sum(vals))";
+        var result = await ResultAsString(query, ";");
+        result.Should().Contain("6").And.Contain("30");
+    }
+
+    [TestMethod]
+    public async Task MvApply_FilterPerRow()
+    {
+        // Expand [1,2,3,4], keep vals>2 -> 3,4.
+        var query =
+            "datatable(id:long, vals:dynamic)[1, dynamic([1,2,3,4])] " +
+            "| mv-apply vals to typeof(long) on (where vals > 2 | project vals)";
+        var result = await ResultAsString(query, ";");
+        // id=1 survives; only vals 3 and 4 pass the filter (1 and 2 are dropped).
+        result.Should().Contain("1,3").And.Contain("1,4");
+        result.Should().NotContain("1,2");
+    }
+
+    [TestMethod]
+    public async Task MvApply_SourceColumnSurvives()
+    {
+        // The source 'id' survives the subquery and is associated with each output row.
+        var query =
+            "datatable(id:long, vals:dynamic)[7, dynamic([1,2,3])] " +
+            "| mv-apply vals to typeof(long) on (summarize s=sum(vals))";
+        var result = await ResultAsString(query, ";");
+        result.Should().Contain("7").And.Contain("6");
+    }
+}

--- a/test/BasicTests/ParseUserAgentFunctionTests.cs
+++ b/test/BasicTests/ParseUserAgentFunctionTests.cs
@@ -1,0 +1,51 @@
+using System.Linq;
+using AwesomeAssertions;
+using KustoLoco.Core;
+using NotNullStrings;
+
+namespace BasicTests;
+
+[TestClass]
+public class ParseUserAgentFunctionTests : TestMethods
+{
+    private sealed class StubUaParser : IUserAgentParser
+    {
+        public UserAgentInfo Parse(string userAgent) => new(
+            Browser: new UserAgentSoftware("Chrome", "120", "0", "0"),
+            OperatingSystem: new UserAgentSoftware("Windows", "10", null, null, null),
+            Device: new UserAgentDevice("Other"));
+    }
+
+    private static string LastLine(KustoQueryResult result) =>
+        result.GetRow(result.RowCount - 1).Select(KustoFormatter.ObjectToKustoString).JoinString();
+
+    [TestMethod]
+    public async Task ParseUserAgent_Browser()
+    {
+        var context = CreateContext();
+        context.AddProvider<IUserAgentParser>(new StubUaParser());
+        var result = await context.RunQuery("print tostring(parse_user_agent('ua-string', 'browser'))");
+        var line = LastLine(result);
+        line.Should().Contain("Chrome");
+        line.Should().Contain("Browser");
+    }
+
+    [TestMethod]
+    public async Task ParseUserAgent_BrowserAndOs()
+    {
+        var context = CreateContext();
+        context.AddProvider<IUserAgentParser>(new StubUaParser());
+        var result = await context.RunQuery("print tostring(parse_user_agent('ua-string', dynamic([\"browser\",\"os\"])))");
+        var line = LastLine(result);
+        line.Should().Contain("Chrome");
+        line.Should().Contain("Windows");
+    }
+
+    [TestMethod]
+    public async Task ParseUserAgent_NoProvider_Null()
+    {
+        var context = CreateContext();
+        var result = await context.RunQuery("print parse_user_agent('ua-string', 'browser')");
+        LastLine(result).Should().Be("<null>");
+    }
+}

--- a/test/BasicTests/SetOperationFunctionTests.cs
+++ b/test/BasicTests/SetOperationFunctionTests.cs
@@ -1,0 +1,42 @@
+using AwesomeAssertions;
+
+namespace BasicTests;
+
+[TestClass]
+public class SetOperationFunctionTests : TestMethods
+{
+    [TestMethod]
+    public async Task SetUnion_TwoArrays() =>
+        (await SquashedLastLineOfResult("print set_union(dynamic([1,2,3]), dynamic([3,4,5]))"))
+            .Should().Be("[1,2,3,4,5]");
+
+    [TestMethod]
+    public async Task SetUnion_ThreeArrays_Dedup() =>
+        (await SquashedLastLineOfResult("print set_union(dynamic([1,2]), dynamic([2,3]), dynamic([3,4]))"))
+            .Should().Be("[1,2,3,4]");
+
+    [TestMethod]
+    public async Task SetIntersect_Common() =>
+        (await SquashedLastLineOfResult("print set_intersect(dynamic([1,2,3,4]), dynamic([2,3,5]))"))
+            .Should().Be("[2,3]");
+
+    [TestMethod]
+    public async Task SetIntersect_ThreeArrays() =>
+        (await SquashedLastLineOfResult("print set_intersect(dynamic([1,2,3]), dynamic([2,3,4]), dynamic([3,4,5]))"))
+            .Should().Be("[3]");
+
+    [TestMethod]
+    public async Task SetDifference_FirstMinusRest() =>
+        (await SquashedLastLineOfResult("print set_difference(dynamic([1,2,3,4]), dynamic([2,4]))"))
+            .Should().Be("[1,3]");
+
+    [TestMethod]
+    public async Task SetDifference_MultipleExcludes() =>
+        (await SquashedLastLineOfResult("print set_difference(dynamic([1,2,3,4,5]), dynamic([2]), dynamic([4]))"))
+            .Should().Be("[1,3,5]");
+
+    [TestMethod]
+    public async Task SetUnion_Strings() =>
+        (await SquashedLastLineOfResult("print set_union(dynamic([\"a\",\"b\"]), dynamic([\"b\",\"c\"]))"))
+            .Should().Be("[\"a\",\"b\",\"c\"]");
+}

--- a/test/BasicTests/UrlFunctionTests.cs
+++ b/test/BasicTests/UrlFunctionTests.cs
@@ -1,0 +1,28 @@
+using AwesomeAssertions;
+
+namespace BasicTests;
+
+[TestClass]
+public class UrlFunctionTests : TestMethods
+{
+    [TestMethod]
+    public async Task ParseUrl_FullUrl() =>
+        (await SquashedLastLineOfResult(
+            "print parse_url('scheme://username:password@host:1234/this/is/a/path?k1=v1&k2=v2#fragment')"))
+            .Should().Be(
+                "{\"Scheme\":\"scheme\",\"Host\":\"host\",\"Port\":\"1234\",\"Path\":\"/this/is/a/path\"," +
+                "\"Username\":\"username\",\"Password\":\"password\"," +
+                "\"QueryParameters\":{\"k1\":\"v1\",\"k2\":\"v2\"},\"Fragment\":\"fragment\"}");
+
+    [TestMethod]
+    public async Task ParseUrl_MinimalHostPath() =>
+        (await SquashedLastLineOfResult("print parse_url('https://contoso.com/a/b')"))
+            .Should().Be(
+                "{\"Scheme\":\"https\",\"Host\":\"contoso.com\",\"Port\":\"\",\"Path\":\"/a/b\"," +
+                "\"Username\":\"\",\"Password\":\"\",\"QueryParameters\":{},\"Fragment\":\"\"}");
+
+    [TestMethod]
+    public async Task ParseUrlQuery() =>
+        (await SquashedLastLineOfResult("print parse_urlquery('k1=v1&k2=v2&k3=v3')"))
+            .Should().Be("{\"QueryParameters\":{\"k1\":\"v1\",\"k2\":\"v2\",\"k3\":\"v3\"}}");
+}


### PR DESCRIPTION
Adds four tabular operators, each as an IR node + translator + evaluator with tests. This covers the `make-series` half of #57 — `series_fir` and `series_subtract` are **not** included here and remain open.

> **Stacked on #646** (the provider seam) — `externaldata` reads its resolver through the seam's provider registry. Merge #645 → #646 first; the net-new work here is the operators. Earlier commits drop out of this diff as the stack lands.

### Operators
- **`mv-apply`** — expands array column(s) per source row into a subtable and runs the subquery; non-expanded columns replicate, shorter arrays null-pad, `RowLimit` honoured.
- **`externaldata`** — resolves the declared schema/URIs/format through a host-registered `IExternalDataResolver`. **Fail-closed**: no resolver → empty table, so URL-allowlisting / SSRF protection / auth live entirely in the host, opt-in.
- **`make-series`** — `from..to..step` and `in range(..)`, `by` grouping, per-aggregate `default` gap-fill. Faithful to the ADX spec: `to` is non-inclusive (`ceil` count), datetime/timespan axes computed in **exact integer ticks** (double drifts above 2^53), missing `default=` fills a **typed 0** (explicit `default=<null>` stays null), result column order matches the Kusto schema `[by…, aggregates…, axis-last]`, and `in range(..)`'s inclusive stop is honoured.
- **`ipv4_lookup`** — the `evaluate ipv4_lookup(LookupTable, SourceKey, IpKey)` plugin; joins each row to the lookup table by CIDR membership (reusing the ipv4 family's helper).

### Engine change
Extends the operator IR-visitor (`IRNodeVisitor` / `DefaultIRNodeVisitor`) with the four `Visit*Operator` methods; `IRTranslator` maps the corresponding Kusto.Language syntax nodes (which already parse). No existing operator is affected.

